### PR TITLE
Fixed condition to log response delay messages

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -122,7 +122,7 @@ function mockResponse(path, proxy, req, res) {
   var scheduleResponse = calculateDelayTime(proxy.config.delay);
   setTimeout(function() {
     writeResponse(path, res);
-    if (proxy.config.delay > 0) {
+    if (scheduleResponse > 0) {
       grunt.log.verbose.writeln('Response delayed by ' + scheduleResponse + ' ms for: ' + req.url);
     }
     grunt.log.writeln('Dispatching request ' + req.url + ' from ' + path);


### PR DESCRIPTION
When proxy.config.delay has literal value (for example 'auto') then comparation 'auto' > 0 was always `false`.
