### PR TITLE
Support `delay` option for 'proxy' mode

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -112,9 +112,9 @@ function calculateDelayTime(mode) {
   }
 }
 
-function proxyResponse(proxy, req, res) {
+function proxyResponse(proxy, req, res, buffer) {
   var target = utils.absoluteUrl(proxy, req.url);
-  proxy.server.proxyRequest(req, res);
+  proxy.server.proxyRequest(req, res, buffer);
   logSuccess('Proxied', proxy, req);
 }
 


### PR DESCRIPTION
Added implementation for 'delay' option for 'proxy' mode to test application on top of the local (and unrealistic quickly) api.
