### PR TITLE
Modified the response handler to retrieve the correct proxy after a rewrite.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -40,7 +40,7 @@ module.exports = {
     }
   },
   handleResponse: function(req, res, response) {
-    var proxy = proxies.getProxy(req.url);
+    var proxy = proxies.getProxy(req.originalUrl);
 
     if (_.isUndefined(proxy)) {
       return;


### PR DESCRIPTION
Fixes seglo/grunt-connect-prism#9.

After a rewrite, recording was failing because `handleResponse()` was looking up the proxy by the rewritten URL instead of the original URL.
