### PR TITLE
Support for the "Location" http header

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -12,9 +12,14 @@ function writeResponse(path, res) {
   var responseStr = fs.readFileSync(path).toString();
   var response = JSON.parse(responseStr);
 
-  res.writeHead(response.statusCode, {
+  var actualResponse = {
     'Content-Type': response.contentType
-  });
+  };
+
+  if ('location' in response) 
+    actualResponse['Location'] = response.location;
+
+  res.writeHead(response.statusCode, actualResponse);
 
   var data = response.data;
   if (typeof data === 'object') {
@@ -59,6 +64,9 @@ function serializeResponse(proxy, res, data) {
     statusCode: res.statusCode,
     data: parseJsonResponse(res, data)
   };
+
+  if ('location' in res.headers)
+    response.location = res.headers['location'];
 
   var path = utils.getMockPath(proxy, res.req.path);
 


### PR DESCRIPTION
The api I'm mocking sometimes send 303 status codes for redirects, connect-prism records and mocks this responses, but the  "Location" header was missing.
