### PR TITLE
Be a bit less verbose by default

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -9,7 +9,7 @@ var proxies = require('./proxies.js');
 function rewriteRequest(req) {
   return function(rule) {
     if (rule.from.test(req.url)) {
-      grunt.log.writeln('Request matched rewrite rule.  Rewriting ' + req.url + ' to ' + rule.to);
+      grunt.verbose.writeln('Request matched rewrite rule.  Rewriting ' + req.url + ' to ' + rule.to);
       req.url = req.url.replace(rule.from, rule.to);
     }
   };

--- a/lib/modes.js
+++ b/lib/modes.js
@@ -64,7 +64,7 @@ function serializeResponse(proxy, req, res, data) {
   var path = utils.getMockPath(proxy, req);
 
   writeMockToDisk(response, path);
-  grunt.log.writeln('Serialized response for ' + res.req.path + ' to ' + path);
+  grunt.verbose.writeln('Serialized response for ' + res.req.path + ' to ' + path);
 }
 
 function serializeEmptyMock(proxy, req, path) {
@@ -78,7 +78,7 @@ function serializeEmptyMock(proxy, req, path) {
   path += '.404';
 
   writeMockToDisk(response, path);
-  grunt.log.writeln('Serialized empty 404 response for ' + req.url + ' to ' + path);
+  grunt.verbose.writeln('Serialized empty 404 response for ' + req.url + ' to ' + path);
 }
 
 function logSuccess(modeMsg, proxy, req) {
@@ -150,7 +150,7 @@ function mockResponse(path, proxy, req, res) {
     if (scheduleResponse > 0) {
       grunt.log.verbose.writeln('Mock response delayed by ' + scheduleResponse + ' ms for: ' + req.url);
     }
-    grunt.log.writeln('Dispatching request ' + req.url + ' from ' + path);
+    grunt.verbose.writeln('Dispatching request ' + req.url + ' from ' + path);
     logSuccess('Mocked', proxy, req);
   }, scheduleResponse);
 }


### PR DESCRIPTION
The verbose output had a tendency to screw up output from test runners.
So only output info messages when --verbose flag is active.
