### PR TITLE
Mockable option , and OPTIONS request

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -8,8 +8,7 @@ var httpProxy = require('http-proxy');
 
 var utils = require('./utils');
 
-function readMockFile(path, res)
-{
+function readMockFile(path, res) {
     var responseStr = fs.readFileSync(path).toString();
     return JSON.parse(responseStr);
 }
@@ -17,226 +16,231 @@ function readMockFile(path, res)
 // TODO: figure out how to buffer file stream into response
 function writeResponse(path, res) {
 
-  var response = readMockFile(path,res);
+    var response = readMockFile(path, res);
 
-  res.writeHead(response.statusCode, {
-    'Content-Type': response.contentType
-  });
+    res.writeHead(response.statusCode, {
+        'Content-Type': response.contentType
+    });
 
-  var data = response.data;
-  if (typeof data === 'object') {
-    data = JSON.stringify(data);
-  }
+    var data = response.data;
+    if (typeof data === 'object') {
+        data = JSON.stringify(data);
+    }
 
-  res.write(data);
-  res.end();
+    res.write(data);
+    res.end();
 }
-
 
 
 function write404(req, res, path) {
-  res.writeHead(404, {
-    'Content-Type': 'text/plain'
-  });
-  res.write('No mock exists for ' + req.url + ' - (' + path + ')');
-  res.end();
+    res.writeHead(404, {
+        'Content-Type': 'text/plain'
+    });
+    res.write('No mock exists for ' + req.url + ' - (' + path + ')');
+    res.end();
 }
 
 function parseJsonResponse(res, data) {
-  var contentType = res.headers['content-type'];
-  if (_.contains(contentType, 'json') || _.contains(contentType, 'javascript')) {
-    try {
-      return JSON.parse(data);
-    } catch (e) {
-      grunt.log.verbose.writeln('Could not parse JSON for response of ' + res.req.path);
+    var contentType = res.headers['content-type'];
+    if (_.contains(contentType, 'json') || _.contains(contentType, 'javascript')) {
+        try {
+            return JSON.parse(data);
+        } catch (e) {
+            grunt.log.verbose.writeln('Could not parse JSON for response of ' + res.req.path);
+        }
     }
-  }
-  return data;
+    return data;
 }
 
 function writeMockToDisk(response, path) {
-  var serializedResponse = JSON.stringify(response, true, 2);
+    var serializedResponse = JSON.stringify(response, true, 2);
 
-  // write file async to disk.  overwrite if it already exists.  prettyprint.
-  fs.writeFile(path, serializedResponse);
+    // write file async to disk.  overwrite if it already exists.  prettyprint.
+    fs.writeFile(path, serializedResponse);
 }
 
 function serializeResponse(proxy, res, data) {
-  var response = {
-    mockable : false,
-    requestUrl: res.req.path,
-    contentType: res.headers['content-type'],
-    statusCode: res.statusCode,
-    data: parseJsonResponse(res, data)
-  };
+    var response = {
+        mockable: false,
+        requestUrl: res.req.path,
+        contentType: res.headers['content-type'],
+        statusCode: res.statusCode,
+        data: parseJsonResponse(res, data)
+    };
 
-  var path = utils.getMockPath(proxy, res.req.path);
+    var path = utils.getMockPath(proxy, res.req.path);
 
-  writeMockToDisk(response, path);
-  grunt.log.writeln('Serialized response for ' + res.req.path + ' to ' + path);
+    writeMockToDisk(response, path);
+    grunt.log.writeln('Serialized response for ' + res.req.path + ' to ' + path);
 }
 
 function serializeEmptyMock(proxy, req, path) {
-  var response = {
-    mockable : false,
-    requestUrl: req.url,
-    contentType: 'application/javascript',
-    statusCode: 200,
-    data: {}
-  };
+    var response = {
+        mockable: false,
+        requestUrl: req.url,
+        contentType: 'application/javascript',
+        statusCode: 200,
+        data: {}
+    };
 
-  path += '.404';
+    path += '.404';
 
-  writeMockToDisk(response, path);
-  grunt.log.writeln('Serialized empty 404 response for ' + req.url + ' to ' + path);
+    writeMockToDisk(response, path);
+    grunt.log.writeln('Serialized empty 404 response for ' + req.url + ' to ' + path);
 }
 
 function logSuccess(modeMsg, proxy, req) {
-  var target = utils.absoluteUrl(proxy, req.url ? req.url : req.path);
-  grunt.log.verbose.writeln(modeMsg + ' request: ' + target);
+    var target = utils.absoluteUrl(proxy, req.url ? req.url : req.path);
+    grunt.log.verbose.writeln(modeMsg + ' request: ' + target);
 }
 
 function calculateDelayTime(mode) {
-  if (!mode || mode === undefined) {
-    return 0;
-  } else if (!isNaN(mode)) {
-    return mode;
-  } else {
-    var lowerBound = 1;
-    var upperBound = 1;
-    switch (mode) {
-      case 'auto':
-        lowerBound = 500;
-        upperBound = 1750;
-        break;
-      case 'fast':
-        lowerBound = 150;
-        upperBound = 1000;
-        break;
-      case 'slow':
-        lowerBound = 1500;
-        upperBound = 3000;
-        break;
+    if (!mode || mode === undefined) {
+        return 0;
+    } else if (!isNaN(mode)) {
+        return mode;
+    } else {
+        var lowerBound = 1;
+        var upperBound = 1;
+        switch (mode) {
+            case 'auto':
+                lowerBound = 500;
+                upperBound = 1750;
+                break;
+            case 'fast':
+                lowerBound = 150;
+                upperBound = 1000;
+                break;
+            case 'slow':
+                lowerBound = 1500;
+                upperBound = 3000;
+                break;
+        }
+        return Math.floor((Math.random() * upperBound) + lowerBound);
     }
-    return Math.floor((Math.random() * upperBound) + lowerBound);
-  }
 }
 
 function proxyResponse(proxy, req, res, buffer) {
-  var target = utils.absoluteUrl(proxy, req.url);
-  proxy.server.proxyRequest(req, res, buffer);
-  logSuccess('Proxied', proxy, req);
+    var target = utils.absoluteUrl(proxy, req.url);
+    proxy.server.proxyRequest(req, res, buffer);
+    logSuccess('Proxied', proxy, req);
 }
 
 function mockResponse(path, proxy, req, res) {
-  /*** delay response with some fake time so mock has behaviour like real world API ***/
-  var scheduleResponse = calculateDelayTime(proxy.config.delay);
-  setTimeout(function() {
-    writeResponse(path, res);
-    if (scheduleResponse > 0) {
-      grunt.log.verbose.writeln('Mock response delayed by ' + scheduleResponse + ' ms for: ' + req.url);
-    }
-    grunt.log.writeln('Dispatching request ' + req.url + ' from ' + path);
-    logSuccess('Mocked', proxy, req);
-  }, scheduleResponse);
+    /*** delay response with some fake time so mock has behaviour like real world API ***/
+    var scheduleResponse = calculateDelayTime(proxy.config.delay);
+    setTimeout(function () {
+        writeResponse(path, res);
+        if (scheduleResponse > 0) {
+            grunt.log.verbose.writeln('Mock response delayed by ' + scheduleResponse + ' ms for: ' + req.url);
+        }
+        grunt.log.writeln('Dispatching request ' + req.url + ' from ' + path);
+        logSuccess('Mocked', proxy, req);
+    }, scheduleResponse);
 }
 function proxyOrMockResponse(path, proxy, req, res, buffer) {
 
     /** determine if mock should be mocked or proxied **/
     var response = readMockFile(path, res);
-    if(response && response.mockable && (response.mockable === true || response.mockable === false))
-    {
+    if (response && response.mockable && (response.mockable === true || response.mockable === false)) {
         /** TODO : File was already readed, buffer response to prevent double reading same file **/
-        if(response.mockable === true)
-        {
+        if (response.mockable === true) {
             mockResponse(path, proxy, req, res);
-        } else if(response.mockable === false)
-        {
+        } else if (response.mockable === false) {
             proxyResponse(proxy, req, res, buffer);
         }
     } else {
-        grunt.log.error('An error occurred while reading mockable option from' + path);
+        proxyResponse(proxy, req, res, buffer);
     }
 }
 
 function uncompress(res, callback) {
-  var contentEncoding = res.headers['content-encoding'];
+    var contentEncoding = res.headers['content-encoding'];
 
-  var method = res;
+    var method = res;
 
-  if (contentEncoding === 'gzip') {
-    method = zlib.createGunzip();
-    res.pipe(method);
-  } else if (contentEncoding === 'deflate') {
-    method = zlib.createInflate();
-    res.pipe(method);
-  }
+    if (contentEncoding === 'gzip') {
+        method = zlib.createGunzip();
+        res.pipe(method);
+    } else if (contentEncoding === 'deflate') {
+        method = zlib.createInflate();
+        res.pipe(method);
+    }
 
-  var buffer = [];
-  method.on('data', function(data) {
-    buffer.push(data.toString());
-  }).on("end", function() {
-    callback(res, buffer.join(''));
-  }).on("error", function(e) {
-    grunt.log.error('An error occurred during decompression: ' + e);
-  });
+    var buffer = [];
+    method.on('data', function (data) {
+        buffer.push(data.toString());
+    }).on("end", function () {
+        callback(res, buffer.join(''));
+    }).on("error", function (e) {
+        grunt.log.error('An error occurred during decompression: ' + e);
+    });
 }
 
 module.exports = {
-  proxy: function(proxy, req, res) {
-    /*** add latency to proxy request ***/
-    var scheduleProxyRequest = calculateDelayTime(proxy.config.delay);
-    var buffer = httpProxy.buffer(req);
+    proxy: function (proxy, req, res) {
+        /*** add latency to proxy request ***/
+        var scheduleProxyRequest = calculateDelayTime(proxy.config.delay);
+        var buffer = httpProxy.buffer(req);
 
-    setTimeout(function() {
-      if (scheduleProxyRequest > 0) {
-        grunt.log.verbose.writeln('Proxy request delayed by ' + scheduleProxyRequest + ' ms for: ' + req.url);
-      }
-      proxyResponse(proxy, req, res, buffer);
-    }, scheduleProxyRequest);
-  },
-  record: function(proxy, res) {
-    uncompress(res, function(res, data) {
-      serializeResponse(proxy, res, data);
-      logSuccess('Recorded', proxy, res.req);
-    });
-  },
-  mock: function(proxy, req, res) {
-    var path = utils.getMockPath(proxy, req.url);
+        setTimeout(function () {
+            if (scheduleProxyRequest > 0) {
+                grunt.log.verbose.writeln('Proxy request delayed by ' + scheduleProxyRequest + ' ms for: ' + req.url);
+            }
+            proxyResponse(proxy, req, res, buffer);
+        }, scheduleProxyRequest);
+    },
+    record: function (proxy, res) {
+        uncompress(res, function (res, data) {
+            serializeResponse(proxy, res, data);
+            logSuccess('Recorded', proxy, res.req);
+        });
+    },
+    mock: function (proxy, req, res) {
+        if(req.method !== 'OPTIONS') {
+            var path = utils.getMockPath(proxy, req.url);
 
-    fs.exists(path, function(exists) {
-      if (exists) {
-        mockResponse(path, proxy, req, res);
-      } else {
-        write404(req, res, path);
-        serializeEmptyMock(proxy, req, path);
-        grunt.log.verbose.writeln('Returned 404 for: ' + req.url);
-      }
-    });
-  },
-  mockrecord: function(proxy, req, res) {
-    var path = utils.getMockPath(proxy, req.url);
+            fs.exists(path, function (exists) {
+                if (exists) {
+                    mockResponse(path, proxy, req, res);
+                } else {
+                    write404(req, res, path);
+                    serializeEmptyMock(proxy, req, path);
+                    grunt.log.verbose.writeln('Returned 404 for: ' + req.url);
+                }
+            });
+        } else {
+            var buffer = httpProxy.buffer(req);
+            proxyResponse(proxy, req, res, buffer);
+        }
+    },
+    mockrecord: function (proxy, req, res) {
+        var path = utils.getMockPath(proxy, req.url);
 
-    fs.exists(path, function(exists) {
-      if (exists) {
-        mockResponse(path, proxy, req, res);
-      } else {
-        proxyResponse(proxy, req, res);
-      }
-    });
-  },
-    hybrid: function(proxy, req, res) {
+        fs.exists(path, function (exists) {
+            if (exists) {
+                mockResponse(path, proxy, req, res);
+            } else {
+                proxyResponse(proxy, req, res);
+            }
+        });
+    },
+    hybrid: function (proxy, req, res) {
         var path = utils.getMockPath(proxy, req.url);
         var buffer = httpProxy.buffer(req);
 
-        fs.exists(path, function(exists) {
-            if (exists) {
-                proxyOrMockResponse(path, proxy, req, res, buffer);
-            } else {
-                write404(req, res, path);
-                serializeEmptyMock(proxy, req, path);
-                grunt.log.verbose.writeln('Returned 404 for: ' + req.url);
-            }
-        });
+        if(req.method !== 'OPTIONS') {
+            fs.exists(path, function (exists) {
+                if (exists) {
+                    proxyOrMockResponse(path, proxy, req, res, buffer);
+                } else {
+                    write404(req, res, path);
+                    serializeEmptyMock(proxy, req, path);
+                    grunt.log.verbose.writeln('Returned 404 for: ' + req.url);
+                }
+            });
+        } else {
+            proxyResponse(proxy, req, res, buffer);
+        }
     }
 };

--- a/lib/modes.js
+++ b/lib/modes.js
@@ -8,10 +8,16 @@ var httpProxy = require('http-proxy');
 
 var utils = require('./utils');
 
+function readMockFile(path, res)
+{
+    var responseStr = fs.readFileSync(path).toString();
+    return JSON.parse(responseStr);
+}
+
 // TODO: figure out how to buffer file stream into response
 function writeResponse(path, res) {
-  var responseStr = fs.readFileSync(path).toString();
-  var response = JSON.parse(responseStr);
+
+  var response = readMockFile(path,res);
 
   res.writeHead(response.statusCode, {
     'Content-Type': response.contentType
@@ -25,6 +31,8 @@ function writeResponse(path, res) {
   res.write(data);
   res.end();
 }
+
+
 
 function write404(req, res, path) {
   res.writeHead(404, {
@@ -55,6 +63,7 @@ function writeMockToDisk(response, path) {
 
 function serializeResponse(proxy, res, data) {
   var response = {
+    mockable : false,
     requestUrl: res.req.path,
     contentType: res.headers['content-type'],
     statusCode: res.statusCode,
@@ -69,6 +78,7 @@ function serializeResponse(proxy, res, data) {
 
 function serializeEmptyMock(proxy, req, path) {
   var response = {
+    mockable : false,
     requestUrl: req.url,
     contentType: 'application/javascript',
     statusCode: 200,
@@ -129,6 +139,24 @@ function mockResponse(path, proxy, req, res) {
     grunt.log.writeln('Dispatching request ' + req.url + ' from ' + path);
     logSuccess('Mocked', proxy, req);
   }, scheduleResponse);
+}
+function proxyOrMockResponse(path, proxy, req, res, buffer) {
+
+    /** determine if mock should be mocked or proxied **/
+    var response = readMockFile(path, res);
+    if(response && response.mockable && (response.mockable === true || response.mockable === false))
+    {
+        /** TODO : File was already readed, buffer response to prevent double reading same file **/
+        if(response.mockable === true)
+        {
+            mockResponse(path, proxy, req, res);
+        } else if(response.mockable === false)
+        {
+            proxyResponse(proxy, req, res, buffer);
+        }
+    } else {
+        grunt.log.error('An error occurred while reading mockable option from' + path);
+    }
 }
 
 function uncompress(res, callback) {
@@ -196,5 +224,19 @@ module.exports = {
         proxyResponse(proxy, req, res);
       }
     });
-  }
+  },
+    hybrid: function(proxy, req, res) {
+        var path = utils.getMockPath(proxy, req.url);
+        var buffer = httpProxy.buffer(req);
+
+        fs.exists(path, function(exists) {
+            if (exists) {
+                proxyOrMockResponse(path, proxy, req, res, buffer);
+            } else {
+                write404(req, res, path);
+                serializeEmptyMock(proxy, req, path);
+                grunt.log.verbose.writeln('Returned 404 for: ' + req.url);
+            }
+        });
+    }
 };

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -19,7 +19,7 @@ function validate(options) {
   }
 
   var mode = options.mode;
-  if (!_.contains(['proxy', 'record', 'mock', 'mockrecord'], options.mode)) {
+  if (!_.contains(['proxy', 'record', 'mock', 'mockrecord','hybrid'], options.mode)) {
     grunt.log.error('Prism mode: \'' + mode + '\' is invalid.');
     return false;
   }


### PR DESCRIPTION
Hello Sean, i found another problem while using this middleware. First is that it is "mocking" OPTIONS request, which is not good because when you are trying to PUT/POST anything , middleware is trying to mock also OPTIONS request , which makes you impossible mock PUT/POST responses because middleware is trying to allocate same json for OPTIONS and corresponding PUT/POST request because url is same , only method is changed. Maybe there should be way to add req.method to hash option so PUT method to same resource is served from another mock than POST or OPTIONS method... 

Also i am inside project with approx 200+ resources and its very difficult do debug only one resource (you need to mock entire application to mock only 1 resource) i added new mode , hybrid , which is reading "mockable" option from json (default false) and when you set it to true, only these jsons are mocked. So you can easily mock only one resource. This is crucial because you can have half application programmed on backend and you want to point to real backend, and half application can be not implemented and point to to mocked jsons. This PR is only demo , if you wanna make any improvements to it , feel free to write me. Thank you .

Milos