### PR TITLE
fix(recording): Avoid all recording in proxy mode

### DIFF
--- a/lib/prism.js
+++ b/lib/prism.js
@@ -51,17 +51,20 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
       return false;
     }
 
-    var mocksPath = config.mocksPath;
-    if (_.isUndefined(mocksPath) || !grunt.file.isDir(mocksPath)) {
-      grunt.file.mkdir(mocksPath);
-      logger.warn('Mocks path did not exist \'' + mocksPath + '\'.  Created.');
-    }
+    // avoid any directory writes unless explicitly in mock/record mode
+    if (mode !== 'proxy') {
+        var mocksPath = config.mocksPath;
+        if (_.isUndefined(mocksPath) || !grunt.file.isDir(mocksPath)) {
+            grunt.file.mkdir(mocksPath);
+            logger.warn('Mocks path did not exist \'' + mocksPath + '\'.  Created.');
+        }
 
-    var targetMocksPath = path.join(mocksPath, config.name);
+        var targetMocksPath = path.join(mocksPath, config.name);
 
-    if (!grunt.file.isDir(targetMocksPath)) {
-      grunt.file.mkdir(targetMocksPath);
-      logger.warn('Target mocks path did not exist \'' + targetMocksPath + '\'.  Created.');
+        if (!grunt.file.isDir(targetMocksPath)) {
+            grunt.file.mkdir(targetMocksPath);
+            logger.warn('Target mocks path did not exist \'' + targetMocksPath + '\'.  Created.');
+        }
     }
 
     if (_.isUndefined(config.host) || _.isUndefined(config.context)) {


### PR DESCRIPTION
I was getting warning log messages in proxy mode

```
>> Mocks path did not exist './mocks'.  Created.
>> Target mocks path did not exist 'mocks/login'.  Created.
```

The readme says that [no recording should happen in proxy mode](https://github.com/Droogans/connect-prism#proxy)

Yet it was writing this directory. This prevents that behavior.
