### PR TITLE
Add new config option for advanced control over the internal proxyServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,25 @@ Default: `false`
 
 Clear the `mocks/target` directory when prism is initialized.  The mocks directory will only be cleared of `.json` and `.json.404` files and is not recursive.  The mocks directory will only be cleared when in `record` or `mockrecord` modes.
 
+#### proxyConfig
+Type: `Object`
+
+Default:
+
+```javascript
+{
+    options: {
+       target: // absolute URL as defined by config https, host, port, and context, override at your own risk
+       xfwd: false, // don't add x-forward headers
+       secure: false, // don't verify SSL certs
+       prependPath: false // don't prepend path to target context when proxying
+    },
+    onProxyCreated: function(proxyServer, prismConfig) { ... } // By default this is a no-op, can be used to attach to events on the proxyServer
+}
+```
+
+Allows configuration of the internal proxyServer to meet more custom proxy needs, see [documentation](https://github.com/nodejitsu/node-http-proxy) for further details. This is for advanced use-cases only and can cause prism to stop working if misconfigured, you have been warned.
+
 ## API
 
 ### Overview

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -32,7 +32,15 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
     rewrite: {},
     mockFilenameGenerator: 'default',
     ignoreParameters: false,
-    clearOnStart: false
+    clearOnStart: false,
+    proxyConfig: {
+        options: {
+          xfwd: false, // don't add x-forward headers
+          secure: false, // don't verify SSL certs
+          prependPath: false // don't prepend path to target context when proxying
+        },
+        onProxyCreated: function(proxyServer, prismConfig) { }
+    }
   };
 
   function validate(config) {
@@ -121,13 +129,13 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
       
       config.requestHandler = getRequestHandler(config).handleRequest;
 
-      var proxyServer = httpProxy.createProxyServer({
+      var defaultProxyConfig = {
         // TODO: support native target URL and deprecate https/host/port/context config
-        target: prismUtils.absoluteUrl(config.https, config.host, config.port, config.context),
-        xfwd: false, // don't add x-forward headers
-        secure: false, // don't verify SSL certs
-        prependPath: false // don't prepend path to target context when proxying
-      });
+        target: prismUtils.absoluteUrl(config.https, config.host, config.port, config.context)
+      };
+
+      var proxyConfig = _.extend(defaultProxyConfig, config.proxyConfig.options);
+      var proxyServer = httpProxy.createProxyServer(proxyConfig);
 
       // handle errors from target server
       proxyServer.on('error', function(err, req, res) {
@@ -157,6 +165,8 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
       });
 
       clearMocks.clear(config);
+
+      config.proxyConfig.onProxyCreated(proxyServer, config);
       logger.log('Prism created for: ' + config.context + ' to ' + config.host + ':' + config.port);
 
       return true;

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -134,7 +134,7 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
         target: prismUtils.absoluteUrl(config.https, config.host, config.port, config.context)
       };
 
-      var proxyConfig = _.extend(defaultProxyConfig, config.proxyConfig.options);
+      var proxyConfig = _.extend(defaultProxyConfig, defaultConfig.proxyConfig.options, config.proxyConfig.options);
       var proxyServer = httpProxy.createProxyServer(proxyConfig);
 
       // handle errors from target server


### PR DESCRIPTION
You can take this or leave it, but I needed some more fine grain control over the proxy server to get it working with google appengine and thought the feature might be appreciated.

Cheers!