### PR TITLE
Fetch the body before handling the request in MockRecord

### DIFF
--- a/lib/modes/mockrecord.js
+++ b/lib/modes/mockrecord.js
@@ -12,14 +12,16 @@ var MockFilenameGenerator = require('../services/mock-filename-generator');
 function MockRecord(logger, prismUtils, mockFilenameGenerator, mock, proxy) {
 
   this.handleRequest = function(req, res, prism) {
-    var path = mockFilenameGenerator.getMockPath(prism, req);
+    prismUtils.getBody(req, function() {
+      var path = mockFilenameGenerator.getMockPath(prism, req);
 
-    fs.exists(path, function(exists) {
-      if (exists) {
-        mock.handleRequest(req, res, prism);
-      } else {
-        proxy.handleRequest(req, res, prism);
-      }
+      fs.exists(path, function(exists) {
+        if (exists) {
+          mock.handleRequest(req, res, prism);
+        } else {
+          proxy.handleRequest(req, res, prism);
+        }
+      });
     });
   };
 }


### PR DESCRIPTION
This will allow `mockFilenameGenerator.getMockPath` to use the request body to generate a filename.