### PR TITLE
Using a passthrough stream to prevent the request one to be ended aft…

### DIFF
--- a/lib/modes/proxy.js
+++ b/lib/modes/proxy.js
@@ -2,6 +2,7 @@
 
 var di = require('di');
 var httpProxy = require('http-proxy');
+var stream = require('stream');
 
 var Logger = require('../services/logger');
 var PrismUtils = require('../services/prism-utils');
@@ -11,7 +12,11 @@ var ResponseDelay = require('../services/response-delay');
 function Proxy(logger, prismUtils, mockFilenameGenerator, responseDelay) {
   function proxyResponse(req, res, prism) {
     if (prism.config.hashFullRequest) {
-      prismUtils.getBody(req);
+      var passThroughStream = stream.PassThrough();
+      req.pipe(passThroughStream);
+      prismUtils.getBody(passThroughStream, function(bodyContent) {
+        req.body = bodyContent;
+      });
     }
     prism.server.web(req, res);
     logger.logSuccess('Proxied', req, prism);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
+    "body-parser": "^1.12.4",
     "compression": "^1.0.11",
     "connect": "^3.1.1",
     "express": "^4.10.1",

--- a/test/express-servers/test-server.js
+++ b/test/express-servers/test-server.js
@@ -1,11 +1,17 @@
 var express = require('express');
-
+var bodyParser = require('body-parser');
 var app = express();
+
+app.use(bodyParser.urlencoded({ extended: false }));
 
 app.disable('etag');
 
 app.all('/test', function(req, res) {
   res.send('a server response');
+});
+
+app.post('/test_post', function(req, res) {
+  res.send(req.body.foo);
 });
 
 app.get('/json', function(req, res) {

--- a/test/integration/proxy-spec.js
+++ b/test/integration/proxy-spec.js
@@ -4,10 +4,12 @@ var assert = require('assert');
 var connect = require('connect');
 var di = require('di');
 var http = require('http');
+var querystring = require('querystring');
 
 var prism = require('../../');
 var testUtils = require('../test-utils');
 var httpGet = testUtils.httpGet;
+var httpPost = testUtils.httpPost;
 
 var injector = new di.Injector([]);
 
@@ -31,6 +33,26 @@ describe('proxy mode', function() {
       assert.equal(data, 'a server response');
       done();
     });
+
+  });
+
+  it('can proxy a post response', function(done) {
+    prism.create({
+      name: 'proxyPostTest',
+      mode: 'proxy',
+      context: '/test_post',
+      host: 'localhost',
+      hashFullRequest: true,
+      port: 8090
+    });
+
+    var postData = querystring.stringify({ 'foo': 'bar' });
+
+    httpPost('/test_post', function(res, data) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(data, 'bar');
+      done();
+    }, postData);
 
   });
 


### PR DESCRIPTION
…er reading its content when using hashFullRequest. That would cause the proxy step to hang waiting to read from a response stream that has already been ended. Fixes #21.