### PR TITLE
Support hashFullRequest for mockrecord mode

### DIFF
--- a/lib/modes/mockrecord.js
+++ b/lib/modes/mockrecord.js
@@ -3,27 +3,37 @@
 var di = require('di');
 var fs = require('fs');
 
-var Logger = require('../services/logger');
 var Mock = require('./mock');
 var PrismUtils = require('../services/prism-utils');
 var PrismProxy = require('./proxy');
 var MockFilenameGenerator = require('../services/mock-filename-generator');
 
-function MockRecord(logger, prismUtils, mockFilenameGenerator, mock, proxy) {
+function MockRecord(prismUtils, mockFilenameGenerator, mock, proxy) {
 
   this.handleRequest = function(req, res, prism) {
-    var path = mockFilenameGenerator.getMockPath(prism, req);
+    function handleMockRecordRequest() {
 
-    fs.exists(path, function(exists) {
-      if (exists) {
-        mock.handleRequest(req, res, prism);
-      } else {
-        proxy.handleRequest(req, res, prism);
-      }
-    });
+      var path = mockFilenameGenerator.getMockPath(prism, req);
+
+      fs.exists(path, function(exists) {
+        if (exists) {
+          mock.handleRequest(req, res, prism);
+        } else {
+          proxy.handleRequest(req, res, prism);
+        }
+      });
+    }
+
+    if (prism.config.hashFullRequest) {
+      prismUtils.getBody(req, function() {
+        handleMockRecordRequest(req, res, prism)
+      });
+    } else {
+      handleMockRecordRequest(req, res, prism)
+    }
   };
 }
 
-di.annotate(MockRecord, new di.Inject(Logger, PrismUtils, MockFilenameGenerator, Mock, PrismProxy));
+di.annotate(MockRecord, new di.Inject(PrismUtils, MockFilenameGenerator, Mock, PrismProxy));
 
 module.exports = MockRecord;

--- a/lib/modes/proxy.js
+++ b/lib/modes/proxy.js
@@ -1,39 +1,54 @@
 'use strict';
 
 var di = require('di');
-var httpProxy = require('http-proxy');
-var stream = require('stream');
 
 var Logger = require('../services/logger');
 var PrismUtils = require('../services/prism-utils');
-var MockFilenameGenerator = require('../services/mock-filename-generator');
 var ResponseDelay = require('../services/response-delay');
 
-function Proxy(logger, prismUtils, mockFilenameGenerator, responseDelay) {
+function Proxy(logger, prismUtils, responseDelay) {
   function proxyResponse(req, res, prism) {
-    if (prism.config.hashFullRequest) {
-      var passThroughStream = stream.PassThrough();
-      req.pipe(passThroughStream);
-      prismUtils.getBody(passThroughStream, function(bodyContent) {
-        req.body = bodyContent;
+
+    if (req.bodyRead) {
+      //re-stream the request body, because it has already been consumed
+      req.removeAllListeners('data');
+      req.removeAllListeners('end');
+
+      process.nextTick(function() {
+        if (req.body) {
+          req.emit('data', new Buffer(req.body))
+        }
+        req.emit('end')
       });
     }
+
     prism.server.web(req, res);
     logger.logSuccess('Proxied', req, prism);
   }
 
   this.handleRequest = function(req, res, prism) {
-    var scheduleProxyRequest = responseDelay.delayTimeInMs(prism.config.delay);
+    function handleProxyRequest() {
+      var scheduleProxyRequest = responseDelay.delayTimeInMs(prism.config.delay);
 
-    setTimeout(function() {
-      if (scheduleProxyRequest > 0) {
-        logger.verboseLog('Proxy request delayed by ' + scheduleProxyRequest + ' ms for: ' + req.url);
-      }
-      proxyResponse(req, res, prism);
-    }, scheduleProxyRequest);
+      setTimeout(function() {
+        if (scheduleProxyRequest > 0) {
+          logger.verboseLog('Proxy request delayed by ' + scheduleProxyRequest + ' ms for: ' + req.url);
+        }
+        proxyResponse(req, res, prism);
+      }, scheduleProxyRequest);
+    }
+
+    if (prism.config.hashFullRequest) {
+      prismUtils.getBody(req, function() {
+        handleProxyRequest(req, res, prism);
+      });
+    } else {
+      handleProxyRequest(req, res, prism);
+    }
   }
+
 }
 
-di.annotate(Proxy, new di.Inject(Logger, PrismUtils, MockFilenameGenerator, ResponseDelay));
+di.annotate(Proxy, new di.Inject(Logger, PrismUtils, ResponseDelay));
 
 module.exports = Proxy;

--- a/lib/services/prism-utils.js
+++ b/lib/services/prism-utils.js
@@ -68,21 +68,26 @@ function PrismUtils() {
    * https://github.com/nodejitsu/node-http-proxy/issues/667
    */
   this.getBody = function(req, bodyCallback) {
-    var buffer = '';
-    req.on('data', function(data) {
-      buffer += data;
+    if (req.bodyRead) {
+      bodyCallback(req.body);
+    } else {
+      var buffer = '';
+      req.on('data', function(data) {
+        buffer += data;
 
-      // Too much POST data, kill the connection!
-      if (buffer.length > 1e6) {
-        req.connection.destroy();
-      }
-    });
-    req.on('end', function() {
-      req.body = buffer;
-      if (bodyCallback) {
-        bodyCallback(buffer);
-      }
-    });
+        // Too much POST data, kill the connection!
+        if (buffer.length > 1e6) {
+          req.connection.destroy();
+        }
+      });
+      req.on('end', function() {
+        req.body = buffer;
+        req.bodyRead = true;
+        if (bodyCallback) {
+          bodyCallback(buffer);
+        }
+      });
+    }
   };
 }
 


### PR DESCRIPTION
Fix for #37.
Request body is consumed before filename is generated, and restreamed when it should be proxied.