### PR TITLE
ensure a string is passed to res.write

### DIFF
--- a/lib/modes/mock.js
+++ b/lib/modes/mock.js
@@ -40,7 +40,7 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
     res.writeHead(response.statusCode, actualResponse);
 
     var data = response.data;
-    if (typeof data === 'object') {
+    if (typeof data !== 'string') {
       data = JSON.stringify(data);
     }
 
@@ -129,7 +129,7 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
     }
 
     prismUtils.getBody(req, function() {
-      handleMockRequest(req, res, prism)
+      handleMockRequest(req, res, prism);
     });
   };
 }


### PR DESCRIPTION
If the body of a recorded response is a boolean or any other type other than string or Buffer, `res.write(data)` will throw an exception:

```
TypeError: first argument must be a string or Buffer
    at ServerResponse.OutgoingMessage.write (http.js:852:11)
    at writeHttpResponse (/Users/danemacaulay/Sites/cirrus/ui/node_modules/connect-prism/lib/modes/mock.js:47:9)
    at null._onTimeout (/Users/danemacaulay/Sites/cirrus/ui/node_modules/connect-prism/lib/modes/mock.js:18:7)
    at Timer.listOnTimeout [as ontimeout] (timers.js:112:15)
```