### PR TITLE
Allow configuration function to decide whether or not to record response

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,29 @@ Default:
 
 Allows configuration of the internal proxyServer to meet more custom proxy needs, see [documentation](https://github.com/nodejitsu/node-http-proxy) for further details. This is for advanced use-cases only and can cause prism to stop working if misconfigured, you have been warned.
 
+#### shouldRecord
+Type: `Function`
+Returns: `Boolean`
+
+Default: `null`
+
+User defined function that recieves the request and response objects and allows for user defined function to determine whether or not a particular request/response should result in a recording stored
+
+Example:
+
+```javascipt
+{
+  name: 'api',
+  mode: 'record',
+  context: '/api',
+  host: 'localhost',
+  port: 8090
+  shouldRecord: function (req, res) {
+      return res.statusCode !== 401;
+  }
+}
+```
+
 ## API
 
 ### Overview

--- a/lib/modes/record.js
+++ b/lib/modes/record.js
@@ -68,8 +68,14 @@ function Record(logger, prismUtils, mockFilenameGenerator, mock) {
 
   this.handleResponse = function(req, res, prism) {
     uncompress(res, function(res, data) {
-      serializeResponse(prism, req, res, data);
-      logger.logSuccess('Recorded', res.req, prism);
+      var doRecord = true;
+      if (prism.config.shouldRecord) {
+          doRecord = prism.config.shouldRecord(req, res);
+      }
+      if (doRecord) {
+        serializeResponse(prism, req, res, data);
+        logger.logSuccess('Recorded', res.req, prism);
+      }
     });
   };
 }


### PR DESCRIPTION
General idea is to allow a user configured function that will be used to decide whether or not a response should be recorded. This can be helpful when dealing with 401s from api's while in `mockrecord` mode

This is a first pass at this idea, suggestions welcome!

@TODO: add tests