### PR TITLE
Fix: check for content type headers before writing

### DIFF
--- a/lib/modes/mock.js
+++ b/lib/modes/mock.js
@@ -29,9 +29,11 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
     var responseStr = fs.readFileSync(path).toString();
     var response = JSON.parse(responseStr);
 
-    var actualResponse = {
-      'Content-Type': response.contentType
-    };
+    var actualResponse = {};
+
+    if (response.contentType) {
+      actualResponse['Content-Type'] = response.contentType;
+    }
 
     if ('location' in response) {
       actualResponse['Location'] = response.location;


### PR DESCRIPTION
In some cases, a `Content-Type` header is not guaranteed to be present, for instance `204` No Content

Only add `Content-Type` if one was stored

Without this check an error is thrown in node:
```_http_outgoing.js:344
    throw new Error('`value` required in setHeader("' + name + '", value).');
    ^

Error: `value` required in setHeader("Content-Type", value).
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:344:11)
    at ServerResponse.writeHead (_http_server.js:180:21)
    at writeHttpResponse (/Users/whipkeyc/projects/DnB/cirrus-ui-build/node_modules/connect-prism/lib/modes/mock.js:40:9)
    at null._onTimeout (/Users/whipkeyc/projects/DnB/cirrus-ui-build/node_modules/connect-prism/lib/modes/mock.js:18:7)
    at Timer.listOnTimeout (timers.js:92:15)```