### PR TITLE
Record additional headers (Issue #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ Example:
 }
 ```
 
+#### recordHeaders
+Type: `Array` or `Boolean`
+
+Default: `false`
+
+Allows recorded mocks to store specific headers that match the given header name array or all headers if set to true.  Note that the `Content-Type` and `Location` headers are always recorded.
+
+
 ## API
 
 ### Overview

--- a/lib/modes/mock.js
+++ b/lib/modes/mock.js
@@ -31,6 +31,10 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
 
     var actualResponse = {};
 
+    if(response.headers) {
+      _.assign(actualResponse, response.headers);
+    }
+
     if (response.contentType) {
       actualResponse['Content-Type'] = response.contentType;
     }

--- a/lib/modes/record.js
+++ b/lib/modes/record.js
@@ -48,6 +48,15 @@ function Record(logger, prismUtils, mockFilenameGenerator, mock) {
       response.location = res.headers['location'];
     }
 
+    var configHeaders = prism.config.recordHeaders;
+    if( configHeaders ) {
+      if(Array.isArray(configHeaders)) {
+        response.headers = _.pick(res.headers, configHeaders.map(function(s){return s.toLowerCase()}));
+      } else {
+        response.headers = res.headers;
+      }
+    }
+
     var path = mockFilenameGenerator.getMockPath(prism, req);
 
     mock.save(response, path);

--- a/mocksToRead/mockTest/f94e3b8c896bbdb11606703f88800b930d7888ed.json
+++ b/mocksToRead/mockTest/f94e3b8c896bbdb11606703f88800b930d7888ed.json
@@ -2,5 +2,8 @@
   "requestUrl": "/recordRequest",
   "contentType": "text/plain",
   "statusCode": 200,
-  "data": "a server response"
+  "data": "a server response",
+  "headers": {
+    "X-Header-1": "Copied"
+  }
 }

--- a/test/express-servers/test-server.js
+++ b/test/express-servers/test-server.js
@@ -11,6 +11,8 @@ app.all('/test', function(req, res) {
     res.send('a server response with proxied header value of "'+ req.headers['x-proxied-header'] +'"');
   }
   else {
+    res.set("X-Header-1", "Recorded");
+    res.set("X-Header-2", "Recorded");
     res.send('a server response');
   }
 });

--- a/test/integration/mock-spec.js
+++ b/test/integration/mock-spec.js
@@ -41,6 +41,7 @@ describe('mock mode', function() {
       assert.equal(res.statusCode, 200);
       assert.equal(res.req.path, '/readRequest');
       assert.equal(res.body, 'a server response');
+      assert.equal(res.headers['x-header-1'], 'Copied');
       done();
     });
   });

--- a/test/integration/record-spec.js
+++ b/test/integration/record-spec.js
@@ -52,6 +52,69 @@ describe('record mode', function() {
         assert.equal(deserializedResponse.contentType, 'text/html; charset=utf-8');
         assert.equal(deserializedResponse.statusCode, 200);
         assert.equal(deserializedResponse.data, 'a server response');
+        assert.equal(deserializedResponse.headers, undefined, "should not have header but does");
+
+        done();
+      });
+    });
+  });
+
+  it('can record a response with specific header', function(done) {
+    prism.create({
+      name: 'recordTest',
+      mode: 'record',
+      context: '/test',
+      host: 'localhost',
+      recordHeaders: ["X-Header-1"],
+      port: 8090
+    });
+
+    var pathToResponse = deleteMock('/test');
+
+    httpGet('/test').then(function(res) {
+      waitForFile(pathToResponse, function(pathToResponse) {
+
+        var recordedResponse = fs.readFileSync(pathToResponse).toString();
+        var deserializedResponse = JSON.parse(recordedResponse);
+
+        assert.equal(_.isUndefined(deserializedResponse), false);
+        assert.equal(deserializedResponse.requestUrl, '/test');
+        assert.equal(deserializedResponse.contentType, 'text/html; charset=utf-8');
+        assert.equal(deserializedResponse.statusCode, 200);
+        assert.equal(deserializedResponse.data, 'a server response');
+        assert.equal(deserializedResponse.headers['x-header-1'], "Recorded", "should have header 'X-Header-1: Recorded' but does not");
+        assert.equal(deserializedResponse.headers['x-header-2'], undefined, "should not have header 'X-Header-2: Recorded' but does");
+
+        done();
+      });
+    });
+  });
+
+  it('can record a response with specific all headers', function(done) {
+    prism.create({
+      name: 'recordTest',
+      mode: 'record',
+      context: '/test',
+      host: 'localhost',
+      recordHeaders: true,
+      port: 8090
+    });
+
+    var pathToResponse = deleteMock('/test');
+
+    httpGet('/test').then(function(res) {
+      waitForFile(pathToResponse, function(pathToResponse) {
+
+        var recordedResponse = fs.readFileSync(pathToResponse).toString();
+        var deserializedResponse = JSON.parse(recordedResponse);
+
+        assert.equal(_.isUndefined(deserializedResponse), false);
+        assert.equal(deserializedResponse.requestUrl, '/test');
+        assert.equal(deserializedResponse.contentType, 'text/html; charset=utf-8');
+        assert.equal(deserializedResponse.statusCode, 200);
+        assert.equal(deserializedResponse.data, 'a server response');
+        assert.equal(deserializedResponse.headers['x-header-1'], "Recorded", "should have header 'X-Header-1: Recorded' but does not");
+        assert.equal(deserializedResponse.headers['x-header-2'], "Recorded", "should have header 'X-Header-2: Recorded' but does not");
 
         done();
       });


### PR DESCRIPTION
https://github.com/seglo/connect-prism/issues/13

In record mode reads configs and creates mock json files with some or all of the actual response's headers.

In mock mode populates headers in the response object that are defined in the mock response json file.
