### PR TITLE
make the maxLength value a configurable parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ function(config, req) {
 }
 ```
 
+#### mockFilenameMaxLength
+
+The maximum length of the generated readable filename. Long filenames can cause issues on Windows and Linux systems
+up to the point where the project cannot be checked out anymore because of the long mock filenames.
+
+##### default
+`255`
+
+
 #### ignoreParameters
 
 Type: `Boolean` or [] of String or Regular expression

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -28,6 +28,7 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
     changeOrigin: false,
     rewrite: {},
     mockFilenameGenerator: 'default',
+    mockFilenameMaxLength: 255,
     ignoreParameters: false,
     clearOnStart: false,
     proxyConfig: {

--- a/lib/services/mock-filename-generator.js
+++ b/lib/services/mock-filename-generator.js
@@ -27,7 +27,7 @@ function MockFilenameGenerator(prismUtils) {
   }
 
   function humanReadableMockFilename(config, req) {
-    var maxLength = 255;
+    var maxLength = config.mockFilenameMaxLength || 255;
     var hash = '_' + defaultMockFilename(config, req);
 
     var url = prismUtils.filterUrl(config, req.url.replace(/\/|\_|\?|\<|\>|\\|\:|\*|\||\"/g,'_'));

--- a/test/unit/mock-filename-generator-spec.js
+++ b/test/unit/mock-filename-generator-spec.js
@@ -84,4 +84,24 @@ describe('mock filename generator', function() {
     assert.equal(mockResponsePath.split(path.sep)[2].length, 255);
     assertPathEqual(mockResponsePath, 'mocks/foo/_is_this_url_really=that&readable=at&all&aBigNumber=9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999_ae2f067764e7839efdb85d791fbe031a9d1f63e9.json');
   });
+
+  it('should support a human readable filename generator function with shorter truncation', function () {
+    var req = {
+      url: '/is/this/url?really=that&readable=at&all&aBigNumber=999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+    };
+
+    var prism = {
+      config: {
+        name: 'foo',
+        mocksPath: './mocks',
+        mockFilenameGenerator: 'humanReadable',
+        mockFilenameMaxLength: 120,
+      }
+    };
+
+    var mockResponsePath = mockFilenameGenerator.getMockPath(prism, req);
+
+    assert.equal(mockResponsePath.split(path.sep)[2].length, 120);
+    assertPathEqual(mockResponsePath, 'mocks/foo/_is_this_url_really=that&readable=at&all&aBigNumber=9999999999999999999999_ae2f067764e7839efdb85d791fbe031a9d1f63e9.json');
+  });
 });


### PR DESCRIPTION
This would fix #48 
Since we also have issues with the long filenames on Linux (Ubuntu) I decided to create a pull request.

While it is possible to override the humanReadable filename generator function, it is much easier to just have a setting for the filename length. You might consider merging this if more people have the same issue. 
Unfortunately it is not that simple to just override the default function without importing all the dependencies into the project.