### PR TITLE
Parse API request body only for API requests

### DIFF
--- a/lib/services/api.js
+++ b/lib/services/api.js
@@ -33,6 +33,9 @@ function Api(prismManager, prism, prismUtils, mock, clearMocks) {
 
   // Handle an api request to /_prism
   this.handleRequest = function(req, res, next) {
+    if(!req.url.startsWith(route)) {
+      return false;
+    }
     prismUtils.getBody(req, function(body) {
       // director should parse JSON for me!
       // https://github.com/flatiron/director/issues/275


### PR DESCRIPTION
The API middleware parsed the request body for all incoming requests to
a Javascript Object and persisted it in `req.body`.
This broke downstream proxy functionality that relies on the body being
a string.

This fix ensures that the API request handler only persists the body as
an object when it's actually called, by testing the route.

Resolves #59.