### PR TITLE
store POST body payload in JSON format if it exists

### DIFF
--- a/lib/modes/record.js
+++ b/lib/modes/record.js
@@ -44,6 +44,20 @@ function Record(logger, prismUtils, mockFilenameGenerator, mock) {
     });
   }
 
+  function parseRequestBody(requestBody) {
+    var rawBody = decodeURIComponent(requestBody);
+    var jsonBody = {};
+
+    rawBody.split("&").forEach(function(s) {
+      var keyValue = s.split("=");
+      var key = keyValue[0];
+      var value = keyValue[1];
+      jsonBody[key] = value;
+    });
+
+    return jsonBody;
+  }
+
   function serializeResponse(prism, req, res, data, isBase64) {
     var response = {
       requestUrl: prismUtils.filterUrl(prism.config, res.req.path),
@@ -53,6 +67,10 @@ function Record(logger, prismUtils, mockFilenameGenerator, mock) {
       data: parseJsonResponse(res, data),
       isBase64: isBase64
     };
+
+    if ('body' in req) {
+      response.requestBody = parseRequestBody(req.body);
+    }
 
     if ('location' in res.headers) {
       response.location = res.headers['location'];


### PR DESCRIPTION
Thank you for the awesome package!
We use the prism server with Protractor, and having a way to check what kind of payload it had for the request helps us to debug when test fails :)
