### PR TITLE
add getmode/:name route

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ When the API is enabled you can access it with the `/_prism` base path of your c
 
 Returns the version of `connect-prism` curreently running.  i.e.) 1.0.0
 
+#### Get mode
+
+`GET` `/_prism/getmode/:prism_name`
+
+`prism_name`: The [`name`](#name) of the prism configuration.
+
 #### Set mode
 
 `POST` `/_prism/setmode/:prism_name/:mode`

--- a/lib/services/api.js
+++ b/lib/services/api.js
@@ -24,6 +24,7 @@ function Api(prismManager, prism, prismUtils, mock, clearMocks) {
 
     router.get(route + '/version', version);
     router.post(route + '/setmode/:name/:mode', setMode);
+    router.get(route + '/getmode/:name', getMode);
     router.post(route + '/create', create);
     router.post(route + '/remove/:name', remove);
     router.post(route + '/override/:name/create', overrideCreate);
@@ -100,6 +101,18 @@ function Api(prismManager, prism, prismUtils, mock, clearMocks) {
       } else {
         error(this, 'An unspecified error occurred while creating prism, check your console.');
       }
+    }
+  }
+
+  function getMode(name) {
+    var prismConfig = prismManager.getByName(name);
+    if (_.isUndefined(prismConfig)) {
+      error(this, 'The prism name specified does not exist.');
+    } else {
+      this.res.writeHead(200, {
+        'Content-Type': 'text/plain',
+      });
+      this.res.end(prismConfig.config.mode);
     }
   }
 

--- a/test/integration/api-spec.js
+++ b/test/integration/api-spec.js
@@ -199,4 +199,32 @@ describe('api', function() {
       });
     });
   });
+
+  describe('get mode', function() {
+    beforeEach(function() {
+      prism.create({
+        name: 'setModeTest',
+        mode: 'proxy',
+        context: '/test',
+        host: 'localhost',
+        port: 8090,
+      });
+      prism.useApi();
+    });
+
+    it('should return mode', function(done) {
+      var pathToResponse = deleteMock('/test');
+      httpGet('/_prism/getmode/setModeTest').then(function(res) {
+        assert.equal(res.body, 'proxy');
+        done();
+      });
+    });
+
+    it('should not accept invalid name', function(done) {
+      httpGet('/_prism/getmode/foo').then(function(res) {
+        assert.equal(res.body, 'The prism name specified does not exist.');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
adds a route to get the mode of a `prism` by sending a GET request to `/_prism/getmode/:name`