### PR TITLE
support dynamic hashFullRequest based on config and req

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ A map of headers to be added to proxied requests.
 
 #### hashFullRequest
 
-Type: `Boolean`
+Type: `Function` | `Boolean`
 
 Default: `false`
 
@@ -225,7 +225,14 @@ Use the request body in conjunction with the request URL in order to generate a 
 
 i.e.) Require two different responses for a POST a request with a payload in the request body.
 
-Thanks to [Matt Philips](https://github.com/mattp-) for requesting and helping get this feature implemented.
+##### A Custom Function
+
+A function can be used to dynamically determine whether to record the full request. This function accepts a function that takes 2 parameters:
+
+1. The prism config associated with this request context.
+2. The request object.
+
+Thanks to [Matt Philips](https://github.com/mattp-) and [Patrick Camacho](https://github.com/camacho) for requesting and helping get this feature implemented.
 
 #### mockFilenameGenerator
 

--- a/lib/modes/proxy.js
+++ b/lib/modes/proxy.js
@@ -37,7 +37,7 @@ function Proxy(logger, prismUtils, responseDelay) {
       }, scheduleProxyRequest);
     }
 
-    if (prism.config.hashFullRequest) {
+    if (prism.config.hashFullRequest(prism.config, req)) {
       prismUtils.getBody(req, function() {
         handleProxyRequest(req, res, prism);
       });

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -123,6 +123,14 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
 
     config.rules = urlRewrite.processRewrites(config.rewrite);
 
+    // make hashFullRequest a function to reduce conditionals throughout code
+    if (!_.isFunction(config.hashFullRequest)) {
+      var hashFullRequest = config.hashFullRequest;
+      config.hashFullRequest = function(config, req) {
+        return hashFullRequest;
+      };
+    }
+
     if (validate(config)) {
 
       config.requestHandler = getRequestHandler(config).handleRequest;

--- a/lib/services/mock-filename-generator.js
+++ b/lib/services/mock-filename-generator.js
@@ -17,7 +17,7 @@ function MockFilenameGenerator(prismUtils) {
   function defaultMockFilename(config, req) {
     var reqData = prismUtils.filterUrl(config, req.url);
     // include request body in hash
-    if (config.hashFullRequest) {
+    if (config.hashFullRequest(config, req)) {
       reqData = req.body + reqData;
     }
 

--- a/test/unit/mock-filename-generator-spec.js
+++ b/test/unit/mock-filename-generator-spec.js
@@ -10,6 +10,7 @@ var MockFilenameGenerator = require('../../lib/services/mock-filename-generator'
 describe('mock filename generator', function() {
   var prismUtils = new PrismUtils();
   var mockFilenameGenerator = new MockFilenameGenerator(prismUtils);
+  var hashFullRequest = function(){};
 
   it('should support overriding of the filename generator function', function() {
     function testFilenameCallback(config, req) {
@@ -20,7 +21,8 @@ describe('mock filename generator', function() {
       config: {
         name: 'foo',
         mocksPath: './mocks',
-        mockFilenameGenerator: testFilenameCallback
+        mockFilenameGenerator: testFilenameCallback,
+        hashFullRequest: hashFullRequest
       }
     };
 
@@ -38,7 +40,8 @@ describe('mock filename generator', function() {
       config: {
         name: 'foo',
         mocksPath: './mocks',
-        mockFilenameGenerator: 'humanReadable'
+        mockFilenameGenerator: 'humanReadable',
+        hashFullRequest: hashFullRequest
       }
     };
 
@@ -57,7 +60,8 @@ describe('mock filename generator', function() {
         name: 'foo',
         mocksPath: './mocks',
         mockFilenameGenerator: 'humanReadable',
-        ignoreParameters: true
+        ignoreParameters: true,
+        hashFullRequest: hashFullRequest
       }
     };
 
@@ -76,7 +80,8 @@ describe('mock filename generator', function() {
             name: 'foo',
             mocksPath: './mocks',
             mockFilenameGenerator: 'humanReadable',
-            ignoreParameters: ['really']
+            ignoreParameters: ['really'],
+            hashFullRequest: hashFullRequest
         }
     };
 
@@ -94,7 +99,8 @@ describe('mock filename generator', function() {
       config: {
         name: 'foo',
         mocksPath: './mocks',
-        mockFilenameGenerator: 'humanReadable'
+        mockFilenameGenerator: 'humanReadable',
+        hashFullRequest: hashFullRequest
       }
     };
 
@@ -115,6 +121,7 @@ describe('mock filename generator', function() {
         mocksPath: './mocks',
         mockFilenameGenerator: 'humanReadable',
         mockFilenameMaxLength: 120,
+        hashFullRequest: hashFullRequest
       }
     };
 


### PR DESCRIPTION
I was running into situations where I wanted to be able to dynamically determine whether to hash the body of the req - moving to a function allows this choice to be made on req by req basis

use case:

```js
hashFullRequest: (config, req) => {
  // we want our api requests to cache the body
  // but we don't want to cache the body of an account request 
  // this let's us load the same user for every req in test
  return !(req.path === '/v1/accounts/get' && req.method === 'POST')
},
```