### PR TITLE
add test:watch and clean up body parsing and restreaming

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,16 @@ module.exports = function(grunt) {
       tests: ['tmp']
     },
 
+    watch: {
+      test: {
+        options: {
+          atBegin: true
+        },
+        files: ['lib/**/*.js'],
+        tasks: ['test'],
+      },
+    },
+
     mochaTest: {
       test: {
         options: {
@@ -77,11 +87,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-express');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
   grunt.registerTask('test', ['clean', 'jshint', 'express:server', 'express:serverCompression', 'connect:server', 'mochaTest']);
 
+  // Watch mode for tests
+  grunt.registerTask('test:watch', ['watch:test']);
+  
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);
 

--- a/lib/modes/mock.js
+++ b/lib/modes/mock.js
@@ -14,11 +14,11 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
   function delayResponse(path, prism, req, res) {
     var scheduleResponse = responseDelay.delayTimeInMs(prism.config.delay);
     setTimeout(function() {
-      writeHttpResponse(path, res);
       if (scheduleResponse > 0) {
         logger.verboseLog('Mock response delayed by ' + scheduleResponse + ' ms for: ' + req.url);
       }
       logger.verboseLog('Dispatching request ' + req.url + ' from ' + path);
+      writeHttpResponse(path, res);
       logger.logSuccess('Mocked', req, prism);
     }, scheduleResponse);
   }
@@ -140,7 +140,7 @@ function Mock(logger, prismUtils, mockFilenameGenerator, responseDelay) {
       });
     }
 
-    prismUtils.getBody(req, function() {
+    prismUtils.getBody(req, res, function() {
       handleMockRequest(req, res, prism);
     });
   };

--- a/lib/modes/mockrecord.js
+++ b/lib/modes/mockrecord.js
@@ -24,7 +24,7 @@ function MockRecord(prismUtils, mockFilenameGenerator, mock, proxy) {
     }
 
     if (prism.config.hashFullRequest) {
-      prismUtils.getBody(req, function() {
+      prismUtils.getBody(req, res, function() {
         handleMockRecordRequest(req, res, prism)
       });
     } else {

--- a/lib/modes/proxy.js
+++ b/lib/modes/proxy.js
@@ -7,20 +7,6 @@ var ResponseDelay = require('../services/response-delay');
 
 function Proxy(logger, prismUtils, responseDelay) {
   function proxyResponse(req, res, prism) {
-
-    if (req.bodyRead) {
-      //re-stream the request body, because it has already been consumed
-      req.removeAllListeners('data');
-      req.removeAllListeners('end');
-
-      process.nextTick(function() {
-        if (req.body) {
-          req.emit('data', new Buffer(req.body))
-        }
-        req.emit('end')
-      });
-    }
-
     prism.server.web(req, res);
     logger.logSuccess('Proxied', req, prism);
   }
@@ -38,7 +24,7 @@ function Proxy(logger, prismUtils, responseDelay) {
     }
 
     if (prism.config.hashFullRequest(prism.config, req)) {
-      prismUtils.getBody(req, function() {
+      prismUtils.getBody(req, res, function() {
         handleProxyRequest(req, res, prism);
       });
     } else {

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -164,6 +164,14 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
         res.end(JSON.stringify(json));
       });
 
+      proxyServer.on('proxyReq', function(proxyReq, req, res, options) {
+        if (req.body) {
+          // if req.body is set, it means the request stream has been
+          // consumed, and we have to write the proxy request manually
+          proxyReq.write(req.body);
+        }
+      });
+
       if (_.includes(['record', 'mockrecord'], config.mode)) {
         config.responseHandler = getResponseHandler(config).handleResponse;
         proxyServer.on('proxyRes', httpEvents.handleResponse);

--- a/lib/services/api.js
+++ b/lib/services/api.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var director = require('director');
+var bodyParser = require('body-parser');
 var pjson = require('../../package.json');
 
 var ClearMocks = require('./clear-mocks');
@@ -32,27 +33,32 @@ function Api(prismManager, prism, prismUtils, mock, clearMocks) {
     router.post(route + '/override/:name/clear', overrideClear);
   };
 
+  this.bodyParser = prismUtils.chainMiddlewares([
+    bodyParser.urlencoded({ extended: true }),
+    bodyParser.json(),
+    function(req, res, next) {
+      if (_.isEqual(req.body, {})) delete req.body;
+      next();
+    }
+  ]);
+
   // Handle an api request to /_prism
   this.handleRequest = function(req, res, next) {
     if(!req.url.startsWith(route)) {
       return false;
     }
-    prismUtils.getBody(req, function(body) {
-      // director should parse JSON for me!
-      // https://github.com/flatiron/director/issues/275
-      try {
-        req.body = JSON.parse(body);
-      } catch (err) {}
+    this.bodyParser(req, res, function() {
+      router.dispatch(req, res
+        /* *** Can't handle error and close response if this isn't a valid request, function(err) {
+        if (err) {
+          console.log('api returning 404');
+          res.writeHead(404);
+          res.end();
+        }
+      }*/
+      );
     });
-    return router.dispatch(req, res
-      /* *** Can't handle error and close response if this isn't a valid request, function(err) {
-      if (err) {
-        console.log('api returning 404');
-        res.writeHead(404);
-        res.end();
-      }
-    }*/
-    );
+    return true;
   };
 
   function version() {

--- a/lib/services/logger.js
+++ b/lib/services/logger.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var winston = require('winston');
 
 var PrismUtils = require('./prism-utils');
@@ -14,8 +15,9 @@ function Logger(prismUtils) {
     })]
   });
 
-  this.useVerboseLog = function() {
-    logger.transports.console.level = 'verbose';
+  this.useVerboseLog = function(useVerbose) {
+    useVerbose = _.isUndefined(useVerbose) ? true : useVerbose;
+    logger.transports.console.level = useVerbose ? 'verbose' : 'info';
   };
 
   this.logSuccess = function(modeMsg, req, prism) {

--- a/lib/services/prism-utils.js
+++ b/lib/services/prism-utils.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
+var bodyParser = require('body-parser');
 
 function PrismUtils() {
   this.isValidMode = function(mode) {
@@ -65,33 +66,19 @@ function PrismUtils() {
     return urlPath;
   };
 
+  this.bodyParser = bodyParser.raw({ type: '*/*' });
+
   /**
    * Get the body of the request so that we can use it to hash a response.
-   *
-   * NOTE: I'm getting the request body here so that we can reference it in the
-   * response when creating a hash.  is there a better way to do this?
-   * issue on node-http-proxy tracker: 
-   * https://github.com/nodejitsu/node-http-proxy/issues/667
    */
-  this.getBody = function(req, bodyCallback) {
-    if (req.bodyRead) {
+  this.getBody = function(req, res, bodyCallback) {
+    if (req.body) {
       bodyCallback(req.body);
     } else {
-      var buffer = '';
-      req.on('data', function(data) {
-        buffer += data;
-
-        // Too much POST data, kill the connection!
-        if (buffer.length > 1e6) {
-          req.connection.destroy();
-        }
-      });
-      req.on('end', function() {
-        req.body = buffer;
-        req.bodyRead = true;
-        if (bodyCallback) {
-          bodyCallback(buffer);
-        }
+      this.bodyParser(req, res, function() {
+        // body-parser sets req.body to {} when there is no body
+        if (_.isEqual(req.body, {})) delete req.body;
+        bodyCallback(req.body);
       });
     }
   };
@@ -100,7 +87,7 @@ function PrismUtils() {
    * File helpers stolen from Grunt
    */
   var pathSeparatorRe = /[\/\\]/g;
-   
+
   function exists() {
     var filepath = path.join.apply(path, arguments);
     return fs.existsSync(filepath);
@@ -130,9 +117,31 @@ function PrismUtils() {
     }, '');
   }
 
+  function chainMiddlewares(middlewares) {
+    if (_.toArray(middlewares).length === 0) {
+      return function(req, res, next) { next(); }
+    } else {
+      return function(req, res, next) {
+        function chain(middlewares) {
+          if (middlewares.length > 0) {
+            return function() {
+              middlewares[0](req, res, chain(middlewares.slice(1)));
+            }
+          } else {
+            return function() {
+              next();
+            }
+          }
+        }
+        chain(middlewares)(req, res, next);
+      }
+    }
+  }
+
   this.exists = exists;
   this.isDir = isDir;
   this.mkdir = mkdir;
+  this.chainMiddlewares = chainMiddlewares;
 }
 
 module.exports = PrismUtils;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-prism",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -98,7 +98,6 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
@@ -131,8 +130,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "chalk": {
       "version": "1.1.3",
@@ -307,8 +305,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
@@ -414,7 +411,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -422,8 +418,7 @@
     "depd": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-      "dev": true
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "destroy": {
       "version": "1.0.4",
@@ -494,8 +489,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -981,28 +975,79 @@
       }
     },
     "grunt-contrib-watch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
+      "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "gaze": "0.5.2",
-        "lodash": "2.4.2",
-        "tiny-lr-fork": "0.0.5"
+        "async": "1.5.2",
+        "gaze": "1.1.2",
+        "lodash": "3.10.1",
+        "tiny-lr": "0.2.1"
       },
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
+        "gaze": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+          "dev": true,
+          "requires": {
+            "globule": "1.2.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "globule": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.4",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
+            }
+          }
+        },
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -1031,6 +1076,12 @@
             "mime-types": "2.1.17",
             "negotiator": "0.5.3"
           }
+        },
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
         },
         "basic-auth": {
           "version": "1.0.4",
@@ -1178,6 +1229,18 @@
           "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
           "dev": true
         },
+        "grunt-contrib-watch": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+          "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
+          "dev": true,
+          "requires": {
+            "async": "0.2.10",
+            "gaze": "0.5.2",
+            "lodash": "2.4.2",
+            "tiny-lr-fork": "0.0.5"
+          }
+        },
         "http-errors": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
@@ -1192,6 +1255,12 @@
           "version": "0.4.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
           "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "mime": {
@@ -1524,13 +1593,18 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
       }
+    },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
     },
     "http-proxy": {
       "version": "1.16.2",
@@ -1550,8 +1624,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1566,8 +1639,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ipaddr.js": {
       "version": "1.5.2",
@@ -1633,6 +1705,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "livereload-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
       "dev": true
     },
     "lodash": {
@@ -1723,8 +1801,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1759,14 +1836,12 @@
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -1875,8 +1950,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multiparty": {
       "version": "3.3.2",
@@ -1933,7 +2007,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -2043,8 +2116,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -2068,7 +2140,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -2204,8 +2275,7 @@
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-      "dev": true
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "shelljs": {
       "version": "0.3.0",
@@ -2227,8 +2297,7 @@
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "dev": true
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
     "stream-counter": {
       "version": "0.2.0",
@@ -2281,6 +2350,119 @@
         "rimraf": "2.2.8"
       }
     },
+    "tiny-lr": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
+      "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
+      "dev": true,
+      "requires": {
+        "body-parser": "1.14.2",
+        "debug": "2.2.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.2.2",
+        "parseurl": "1.3.2",
+        "qs": "5.1.0"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+          "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
+          "dev": true,
+          "requires": {
+            "bytes": "2.2.0",
+            "content-type": "1.0.4",
+            "debug": "2.2.0",
+            "depd": "1.1.1",
+            "http-errors": "1.3.1",
+            "iconv-lite": "0.4.13",
+            "on-finished": "2.3.0",
+            "qs": "5.2.0",
+            "raw-body": "2.1.7",
+            "type-is": "1.6.15"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+              "dev": true
+            }
+          }
+        },
+        "bytes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+          "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.7.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "statuses": "1.3.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "qs": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+          "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+          "dev": true,
+          "requires": {
+            "bytes": "2.4.0",
+            "iconv-lite": "0.4.13",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+              "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "tiny-lr-fork": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
@@ -2326,7 +2508,6 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
@@ -2356,8 +2537,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -2375,6 +2555,22 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
       "integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=",
+      "dev": true
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": "0.4.9",
+        "websocket-extensions": "0.1.2"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
+      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Record, mock, and proxy HTTP traffic.",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "test:watch": "grunt test:watch"
   },
   "repository": {
     "type": "git",
@@ -35,6 +36,7 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-watch": "^1.0.0",
     "grunt-express": "^1.4.1",
     "grunt-mocha-test": "^0.13.2",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "body-parser": "^1.15.2",
     "compression": "^1.6.2",
     "connect": "^3.5.0",
     "express": "^4.14.0",
@@ -43,6 +42,7 @@
     "querystring": "^0.2.0"
   },
   "dependencies": {
+    "body-parser": "^1.18.2",
     "director": "^1.2.8",
     "forwarded-for": "^1.0.0",
     "http-proxy": "^1.13.1",

--- a/test/integration/api-spec.js
+++ b/test/integration/api-spec.js
@@ -105,7 +105,7 @@ describe('api', function() {
           "data": "an overidden server response"
         }
       });
-      httpPost('/_prism/override/overrideCreateTest/create', postData).then(function(res) {
+      httpPost('/_prism/override/overrideCreateTest/create', postData, 'application/json').then(function(res) {
         assert.equal(res.body, 'OK');
         return httpGet('/test');
       }).then(function(res) {
@@ -129,7 +129,7 @@ describe('api', function() {
         "url": "/test",
         "body": ""
       });
-      httpPost('/_prism/override/overrideRemoveTest/remove', postData).then(function(res) {
+      httpPost('/_prism/override/overrideRemoveTest/remove', postData, 'application/json').then(function(res) {
         assert.equal(res.body, 'OK');
         return httpGet('/test');
       }).then(function(res) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -82,15 +82,15 @@ exports.deleteMocks = function(paths) {
   });
 };
 
-exports.httpPost = function(path, body) {
-  return exports.httpCall('POST', path, body);
+exports.httpPost = function(path, body, contentType) {
+  return exports.httpCall('POST', path, body, contentType);
 };
 
-exports.httpGet = function(path, body) {
-  return exports.httpCall('GET', path, body);
+exports.httpGet = function(path, body, contentType) {
+  return exports.httpCall('GET', path, body, contentType);
 };
 
-exports.httpCall = function(method, path, body) {
+exports.httpCall = function(method, path, body, contentType) {
   var deferred = q.defer();
   var options = {
     host: 'localhost',
@@ -109,7 +109,7 @@ exports.httpCall = function(method, path, body) {
 
   if (body) {
     options.headers = {
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': contentType || 'application/x-www-form-urlencoded',
       'Content-Length': body.length
     };
     req = http.request(options, cb);


### PR DESCRIPTION
ran into some issues where the proxied req body would sometimes be malformed because of how the request stream was being read. 

this error was particularly problematic if the request was binary and the characters were non-ASCII. instead of using a string, this implementation uses a series of open source middleware parsers to handle reading the stream and placing it on the `req` object, and then emits a `write` even on the `proxyReq`

in addition, i added `grunt-contrib-watch`, a `test:watch` Grunt task, and a `test:watch` npm script, because i wanted the tests to be re-running while i was debugging
```sh
npm run test:watch
```