### PR TITLE
Remove dodgy request parsing

### DIFF
--- a/lib/modes/record.js
+++ b/lib/modes/record.js
@@ -44,20 +44,6 @@ function Record(logger, prismUtils, mockFilenameGenerator, mock) {
     });
   }
 
-  function parseRequestBody(requestBody) {
-    var rawBody = decodeURIComponent(requestBody);
-    var jsonBody = {};
-
-    rawBody.split("&").forEach(function(s) {
-      var keyValue = s.split("=");
-      var key = keyValue[0];
-      var value = keyValue[1];
-      jsonBody[key] = value;
-    });
-
-    return jsonBody;
-  }
-
   function serializeResponse(prism, req, res, data, isBase64) {
     var response = {
       requestUrl: prismUtils.filterUrl(prism.config, res.req.path),
@@ -67,10 +53,6 @@ function Record(logger, prismUtils, mockFilenameGenerator, mock) {
       data: parseJsonResponse(res, data),
       isBase64: isBase64
     };
-
-    if ('body' in req) {
-      response.requestBody = parseRequestBody(req.body);
-    }
 
     if ('location' in res.headers) {
       response.location = res.headers['location'];


### PR DESCRIPTION
In record mode the request payload was being parsed by a call to
`decodeURIComponent` which assumes the payload is URI-encoded.

This is not always true, and may throw exceptions if the payload
contains illegal characters. Surprisingly this is apparently not
that common, but definitely happens with binary payloads.

In addition, this logic was not apparently used anywhere in the
connect-prism code itself, and was added as a convenience by a
contributor. This functionality is best provided via middleware
anyway