### PR TITLE
remove json specific error message (messing with websocket proxying)

### DIFF
--- a/lib/prism.js
+++ b/lib/prism.js
@@ -152,16 +152,7 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
         var address = forwarded(req, req.headers),
           json;
         logger.verboseLog(util.format('[proxy error] %s | %s %s %s', address.ip, req.method, req.url, err.message));
-        if (!res.headersSent) {
-          res.writeHead(500, {
-            'content-type': 'application/json'
-          });
-        }
-        json = {
-          error: 'proxy_error',
-          reason: err.message
-        };
-        res.end(JSON.stringify(json));
+        res.status(500).end(err.message);
       });
 
       proxyServer.on('proxyReq', function(proxyReq, req, res, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-prism",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Record, mock, and proxy HTTP traffic.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
this was causing errors when proxying websockets, and assumed that the res type should be json