### PR TITLE
updated the proxy error handling to be more defensive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ mocks/*
 mocksToRead/**/*.404
 mocksToRead/mockRecordTest/97bb3894d4aa3418d821bdc6f3a9a1ba792739e8.json
 .idea
+.vscode

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -152,7 +152,16 @@ function Prism(prismManager, logger, urlRewrite, httpEvents, proxy, mock, record
         var address = forwarded(req, req.headers),
           json;
         logger.verboseLog(util.format('[proxy error] %s | %s %s %s', address.ip, req.method, req.url, err.message));
-        res.status(500).end(err.message);
+        
+        // Not all res types will have `writeHead` available (web socket errors, for example)
+        if (!res.headersSent && res.writeHead) {
+          res.writeHead(500);
+        } else {
+          // This will be ignored if the headers are already sent
+          res.statusCode = 500;
+        }
+
+        res.end(err.message);
       });
 
       proxyServer.on('proxyReq', function(proxyReq, req, res, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-prism",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Record, mock, and proxy HTTP traffic.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
bug fixing - `res.status` is not necessarily on the response object and can cause errors to be thrown. bumped the version in `package.json`, too