### PR TITLE
Add support for custom ranges for delays

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
         options: {
           atBegin: true
         },
-        files: ['lib/**/*.js'],
+        files: ['lib/**/*.js', 'test/**/*.js'],
         tasks: ['test'],
       },
     },

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ The http scheme of the API you are proxying.  `true` === `https`, `false` === `h
 
 #### delay
 
-Type: `String` or `Integer`
+Type: `String` or `Integer` or `Object`
 
 Default: 0
 
-Values: A number in milliseconds | `'auto'` | `'fast'` | `'slow'`
+Values: A number in milliseconds | `'auto'` | `'fast'` | `'slow'` | `{ lowerBound: Number, upperBound: Number}`
 
 Delay will work with all modes.
 
@@ -189,6 +189,9 @@ You can configure an exact delay in milliseconds or one of the precreated option
 * auto: 500 to 1750 ms
 * fast: 150 to 1000 ms
 * slow: 1500 to 3000 ms
+
+You can further customize the delays by giving an object specifying the lower and upper bounds.
+The full behavior of the feature is described in [unit tests](./test/unit/response-delay.spec.js)
 
 Thanks again to [Miloš Mošovský](https://github.com/MilosMosovsky) for this feature.
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var logger = new Logger(prismUtils);
 var urlRewrite = new UrlRewrite(logger);
 var prismManager = new PrismManager();
 var httpEvents = new HttpEvents(prismManager, urlRewrite, prismUtils);
-var responseDelay = new ResponseDelay();
+var responseDelay = new ResponseDelay(Math.random);
 var proxy = new PrismProxy(logger, prismUtils, responseDelay);
 
 var mockFilenameGenerator = new MockFilenameGenerator(prismUtils);

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function ResponseDelay() {
+function ResponseDelay(randomNumberGenerator) {
   /**
    * Calculate the time in milliseconds based on the delay configuration object
    * delay: Int | 'auto' | 'fast' | 'slow'
@@ -27,7 +27,7 @@ function ResponseDelay() {
           upperBound = 3000;
           break;
       }
-      return Math.floor((Math.random() * upperBound) + lowerBound);
+      return Math.floor((randomNumberGenerator() * upperBound) + lowerBound);
     }
   };
 }

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -33,12 +33,12 @@ function ResponseDelay(randomNumberGenerator) {
       return parseInt(delay);
     }
 
-    var matchingRange = delay;
+    var range = delay;
     if (typeof delay === 'string') {
-      matchingRange = ranges[delay] || ranges.default
+      range = ranges[delay] || ranges.default
     }
-    var lowerBound = matchingRange.lowerBound;
-    var upperBound = matchingRange.upperBound;
+    var lowerBound = range.lowerBound;
+    var upperBound = range.upperBound;
     return Math.floor((randomNumberGenerator() * (upperBound - lowerBound)) + lowerBound);
   };
 }

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -9,7 +9,7 @@ function ResponseDelay(randomNumberGenerator) {
     if (!delay) {
       return 0;
     } else if (!isNaN(delay)) {
-      return delay;
+      return parseInt(delay);
     } else {
       var lowerBound = 1;
       var upperBound = 1;

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -33,7 +33,10 @@ function ResponseDelay(randomNumberGenerator) {
       return parseInt(delay);
     }
 
-    var matchingRange = ranges[delay] || ranges.default;
+    var matchingRange = delay;
+    if (typeof delay === 'string') {
+      matchingRange = ranges[delay] || ranges.default
+    }
     var lowerBound = matchingRange.lowerBound;
     var upperBound = matchingRange.upperBound;
     return Math.floor((randomNumberGenerator() * (upperBound - lowerBound)) + lowerBound);

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -6,7 +6,7 @@ function ResponseDelay(randomNumberGenerator) {
    * delay: Int | 'auto' | 'fast' | 'slow'
    */
   this.delayTimeInMs = function(delay) {
-    if (!delay || delay === undefined) {
+    if (!delay) {
       return 0;
     } else if (!isNaN(delay)) {
       return delay;

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -27,7 +27,7 @@ function ResponseDelay(randomNumberGenerator) {
           upperBound = 3000;
           break;
       }
-      return Math.floor((randomNumberGenerator() * upperBound) + lowerBound);
+      return Math.floor((randomNumberGenerator() * (upperBound - lowerBound)) + lowerBound);
     }
   };
 }

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -24,7 +24,7 @@ function ResponseDelay(randomNumberGenerator) {
    * Calculate the time in milliseconds based on the delay configuration object
    * delay: Int | 'auto' | 'fast' | 'slow'
    */
-  this.delayTimeInMs = function (delay) {
+  this.delayTimeInMs = function(delay) {
     if (!delay) {
       return 0;
     }

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -27,14 +27,16 @@ function ResponseDelay(randomNumberGenerator) {
   this.delayTimeInMs = function (delay) {
     if (!delay) {
       return 0;
-    } else if (!isNaN(delay)) {
-      return parseInt(delay);
-    } else {
-      var matchingRange = ranges[delay] || ranges.default;
-      var lowerBound = matchingRange.lowerBound;
-      var upperBound = matchingRange.upperBound;
-      return Math.floor((randomNumberGenerator() * (upperBound - lowerBound)) + lowerBound);
     }
+
+    if (!isNaN(delay)) {
+      return parseInt(delay);
+    }
+
+    var matchingRange = ranges[delay] || ranges.default;
+    var lowerBound = matchingRange.lowerBound;
+    var upperBound = matchingRange.upperBound;
+    return Math.floor((randomNumberGenerator() * (upperBound - lowerBound)) + lowerBound);
   };
 }
 

--- a/lib/services/response-delay.js
+++ b/lib/services/response-delay.js
@@ -1,32 +1,38 @@
 'use strict';
 
+var ranges = {
+  default: {
+    lowerBound: 1,
+    upperBound: 1,
+  },
+  auto: {
+    lowerBound: 500,
+    upperBound: 1750,
+  },
+  fast: {
+    lowerBound: 150,
+    upperBound: 1000,
+  },
+  slow: {
+    lowerBound: 1500,
+    upperBound: 3000,
+  }
+}
+
 function ResponseDelay(randomNumberGenerator) {
   /**
    * Calculate the time in milliseconds based on the delay configuration object
    * delay: Int | 'auto' | 'fast' | 'slow'
    */
-  this.delayTimeInMs = function(delay) {
+  this.delayTimeInMs = function (delay) {
     if (!delay) {
       return 0;
     } else if (!isNaN(delay)) {
       return parseInt(delay);
     } else {
-      var lowerBound = 1;
-      var upperBound = 1;
-      switch (delay) {
-        case 'auto':
-          lowerBound = 500;
-          upperBound = 1750;
-          break;
-        case 'fast':
-          lowerBound = 150;
-          upperBound = 1000;
-          break;
-        case 'slow':
-          lowerBound = 1500;
-          upperBound = 3000;
-          break;
-      }
+      var matchingRange = ranges[delay] || ranges.default;
+      var lowerBound = matchingRange.lowerBound;
+      var upperBound = matchingRange.upperBound;
       return Math.floor((randomNumberGenerator() * (upperBound - lowerBound)) + lowerBound);
     }
   };

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -13,28 +13,28 @@ describe('Response delay', function () {
 
   describe('No delay', function () {
     it('should have no delay by default', function () {
-      assert(responseDelay.delayTimeInMs() === 0);
+      assert.equal(responseDelay.delayTimeInMs(), 0);
     });
 
     it('should have no delay when given null parameter', function () {
-      assert(responseDelay.delayTimeInMs(null) === 0);
+      assert.equal(responseDelay.delayTimeInMs(null), 0);
     });
 
     it('should have no delay when given a parameter that coerce to false', function () {
-      assert(responseDelay.delayTimeInMs(false) === 0);
-      assert(responseDelay.delayTimeInMs(0) === 0);
-      assert(responseDelay.delayTimeInMs('') === 0);
-      assert(responseDelay.delayTimeInMs(NaN) === 0);
+      assert.equal(responseDelay.delayTimeInMs(false), 0);
+      assert.equal(responseDelay.delayTimeInMs(0), 0);
+      assert.equal(responseDelay.delayTimeInMs(''), 0);
+      assert.equal(responseDelay.delayTimeInMs(NaN), 0);
     });
   });
 
   describe('Simple delays', function () {
     it('should have a simple delay when given a number', function () {
-      assert(responseDelay.delayTimeInMs(42) === 42);
+      assert.equal(responseDelay.delayTimeInMs(42), 42);
     });
 
     it('should have a simple delay when given a string that coerce to a number', function () {
-      assert(responseDelay.delayTimeInMs('42') === 42);
+      assert.equal(responseDelay.delayTimeInMs('42'), 42);
     });
   });
 
@@ -48,19 +48,19 @@ describe('Response delay', function () {
       });
 
       it('should have minimum delay of 500ms when using auto parameter', function () {
-        assert(responseDelay.delayTimeInMs('auto') === 500);
+        assert.equal(responseDelay.delayTimeInMs('auto'), 500);
       });
 
       it('should have minimum delay of 150ms when using fast parameter', function () {
-        assert(responseDelay.delayTimeInMs('fast') === 150);
+        assert.equal(responseDelay.delayTimeInMs('fast'), 150);
       });
 
       it('should have minimum delay of 1500ms when using slow parameter', function () {
-        assert(responseDelay.delayTimeInMs('slow') === 1500);
+        assert.equal(responseDelay.delayTimeInMs('slow'), 1500);
       });
 
       it('should have minimum delay of 1ms when given an invalid parameter', function () {
-        assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
+        assert.equal(responseDelay.delayTimeInMs('invalid parameter'), 1);
       });
     });
 
@@ -73,19 +73,19 @@ describe('Response delay', function () {
       });
 
       it('should have maximum delay of 1750ms when using auto parameter', function () {
-        assert(responseDelay.delayTimeInMs('auto') === 1750);
+        assert.equal(responseDelay.delayTimeInMs('auto'), 1750);
       });
 
       it('should have maximum delay of 1000ms when using fast parameter', function () {
-        assert(responseDelay.delayTimeInMs('fast') === 1000);
+        assert.equal(responseDelay.delayTimeInMs('fast'), 1000);
       });
 
       it('should have maximum delay of 3000ms when using slow parameter', function () {
-        assert(responseDelay.delayTimeInMs('slow') === 3000);
+        assert.equal(responseDelay.delayTimeInMs('slow'), 3000);
       });
 
       it('should have maximum delay of 1ms when given an invalid parameter', function () {
-        assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
+        assert.equal(responseDelay.delayTimeInMs('invalid parameter'), 1);
       });
     });
 
@@ -115,7 +115,7 @@ describe('Response delay', function () {
       };
       responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
 
-      assert(responseDelay.delayTimeInMs('fast') === 150);
+      assert.equal(responseDelay.delayTimeInMs('fast'), 150);
     });
   });
 });

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -33,5 +33,30 @@ describe('Response delay', function() {
             assert(responseDelay.delayTimeInMs(42) === 42);
         });
     });
+
+    describe('Ranged delays', function() {
+        describe('Lower range', function() {
+            beforeEach(function() {
+                var fakeRandomNumberGenerator = function() {return 0;};
+                responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+            });
+
+            it('should have minimum delay of 500ms when using auto parameter', function() {
+                assert(responseDelay.delayTimeInMs('auto') === 500);
+            });
+
+            it('should have minimum delay of 150ms when using fast parameter', function() {
+                assert(responseDelay.delayTimeInMs('fast') === 150);
+            });
+
+            it('should have minimum delay of 1500ms when using slow parameter', function() {
+                assert(responseDelay.delayTimeInMs('slow') === 1500);
+            });
+
+            it('should have minimum delay of 1ms when given an invalid parameter', function() {
+                assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
+            });
+        });
+    });
 });
 

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -27,5 +27,11 @@ describe('Response delay', function() {
             assert(responseDelay.delayTimeInMs(NaN) === 0);
         });
     });
+
+    describe('Simple delays', function() {
+        it('should have a simple delay when given a number', function() {
+            assert(responseDelay.delayTimeInMs(42) === 42);
+        });
+    });
 });
 

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var assert = require('assert');
+
+var ResponseDelay = require('../../lib/services/response-delay');
+
+describe('Response delay', function() {
+    var responseDelay;
+
+    beforeEach(function() {
+        responseDelay = new ResponseDelay();
+    });
+
+    describe('No delay', function() {
+        it('should have no delay by default', function() {
+            assert(responseDelay.delayTimeInMs() === 0);
+        });
+
+        it('should have no delay when given null parameter', function() {
+            assert(responseDelay.delayTimeInMs(null) === 0);
+        });
+
+        it('should have no delay when given a parameter that coerce to false', function() {
+            assert(responseDelay.delayTimeInMs(false) === 0);
+            assert(responseDelay.delayTimeInMs(0) === 0);
+            assert(responseDelay.delayTimeInMs('') === 0);
+            assert(responseDelay.delayTimeInMs(NaN) === 0);
+        });
+    });
+});
+

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -57,6 +57,29 @@ describe('Response delay', function() {
                 assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
             });
         });
+
+        describe('Upper range', function() {
+            beforeEach(function() {
+                var fakeRandomNumberGenerator = function() {return 1;};
+                responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+            });
+
+            it('should have maximum delay of 1750ms when using auto parameter', function() {
+                assert(responseDelay.delayTimeInMs('auto') === 1750);
+            });
+
+            it('should have maximum delay of 1000ms when using fast parameter', function() {
+                assert(responseDelay.delayTimeInMs('fast') === 1000);
+            });
+
+            it('should have maximum delay of 3000ms when using slow parameter', function() {
+                assert(responseDelay.delayTimeInMs('slow') === 3000);
+            });
+
+            it('should have maximum delay of 1ms when given an invalid parameter', function() {
+                assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
+            });
+        });
     });
 });
 

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -80,6 +80,13 @@ describe('Response delay', function() {
                 assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
             });
         });
+
+        it('should round delays to the millisecond', function() {
+            var fakeRandomNumberGenerator = function() {return 0.001;};
+            responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+
+            assert(responseDelay.delayTimeInMs('fast') === 150);
+        });
     });
 });
 

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -4,23 +4,23 @@ var assert = require('assert');
 
 var ResponseDelay = require('../../lib/services/response-delay');
 
-describe('Response delay', function () {
+describe('Response delay', function() {
   var responseDelay;
 
-  beforeEach(function () {
+  beforeEach(function() {
     responseDelay = new ResponseDelay();
   });
 
-  describe('No delay', function () {
-    it('should have no delay by default', function () {
+  describe('No delay', function() {
+    it('should have no delay by default', function() {
       assert.equal(responseDelay.delayTimeInMs(), 0);
     });
 
-    it('should have no delay when given null parameter', function () {
+    it('should have no delay when given null parameter', function() {
       assert.equal(responseDelay.delayTimeInMs(null), 0);
     });
 
-    it('should have no delay when given a parameter that coerce to false', function () {
+    it('should have no delay when given a parameter that coerce to false', function() {
       assert.equal(responseDelay.delayTimeInMs(false), 0);
       assert.equal(responseDelay.delayTimeInMs(0), 0);
       assert.equal(responseDelay.delayTimeInMs(''), 0);
@@ -28,70 +28,70 @@ describe('Response delay', function () {
     });
   });
 
-  describe('Simple delays', function () {
-    it('should have a simple delay when given a number', function () {
+  describe('Simple delays', function() {
+    it('should have a simple delay when given a number', function() {
       assert.equal(responseDelay.delayTimeInMs(42), 42);
     });
 
-    it('should have a simple delay when given a string that coerce to a number', function () {
+    it('should have a simple delay when given a string that coerce to a number', function() {
       assert.equal(responseDelay.delayTimeInMs('42'), 42);
     });
   });
 
-  describe('Ranged delays', function () {
-    describe('Lower range', function () {
-      beforeEach(function () {
-        var fakeRandomNumberGenerator = function () {
+  describe('Ranged delays', function() {
+    describe('Lower range', function() {
+      beforeEach(function() {
+        var fakeRandomNumberGenerator = function() {
           return 0;
         };
         responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
       });
 
-      it('should have minimum delay of 500ms when using auto parameter', function () {
+      it('should have minimum delay of 500ms when using auto parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('auto'), 500);
       });
 
-      it('should have minimum delay of 150ms when using fast parameter', function () {
+      it('should have minimum delay of 150ms when using fast parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('fast'), 150);
       });
 
-      it('should have minimum delay of 1500ms when using slow parameter', function () {
+      it('should have minimum delay of 1500ms when using slow parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('slow'), 1500);
       });
 
-      it('should have minimum delay of 1ms when given an invalid parameter', function () {
+      it('should have minimum delay of 1ms when given an invalid parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('invalid parameter'), 1);
       });
     });
 
-    describe('Upper range', function () {
-      beforeEach(function () {
-        var fakeRandomNumberGenerator = function () {
+    describe('Upper range', function() {
+      beforeEach(function() {
+        var fakeRandomNumberGenerator = function() {
           return 1;
         };
         responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
       });
 
-      it('should have maximum delay of 1750ms when using auto parameter', function () {
+      it('should have maximum delay of 1750ms when using auto parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('auto'), 1750);
       });
 
-      it('should have maximum delay of 1000ms when using fast parameter', function () {
+      it('should have maximum delay of 1000ms when using fast parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('fast'), 1000);
       });
 
-      it('should have maximum delay of 3000ms when using slow parameter', function () {
+      it('should have maximum delay of 3000ms when using slow parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('slow'), 3000);
       });
 
-      it('should have maximum delay of 1ms when given an invalid parameter', function () {
+      it('should have maximum delay of 1ms when given an invalid parameter', function() {
         assert.equal(responseDelay.delayTimeInMs('invalid parameter'), 1);
       });
     });
 
     describe('Custom ranges', function() {
-      it('should use the given upper bound to calculate the delay', function () {
-        var fakeRandomNumberGenerator = function () {
+      it('should use the given upper bound to calculate the delay', function() {
+        var fakeRandomNumberGenerator = function() {
           return 1;
         };
         responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
@@ -99,8 +99,8 @@ describe('Response delay', function () {
         assert.equal(responseDelay.delayTimeInMs({lowerBound: 50, upperBound: 100}), 100);
       });
 
-      it('should use the given lower bound to calculate the delay', function () {
-        var fakeRandomNumberGenerator = function () {
+      it('should use the given lower bound to calculate the delay', function() {
+        var fakeRandomNumberGenerator = function() {
           return 0;
         };
         responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
@@ -109,8 +109,8 @@ describe('Response delay', function () {
       });
     });
 
-    it('should round delays to the millisecond', function () {
-      var fakeRandomNumberGenerator = function () {
+    it('should round delays to the millisecond', function() {
+      var fakeRandomNumberGenerator = function() {
         return 0.001;
       };
       responseDelay = new ResponseDelay(fakeRandomNumberGenerator);

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -32,6 +32,10 @@ describe('Response delay', function() {
         it('should have a simple delay when given a number', function() {
             assert(responseDelay.delayTimeInMs(42) === 42);
         });
+
+        it('should have a simple delay when given a string that coerce to a number', function() {
+            assert(responseDelay.delayTimeInMs('42') === 42);
+        });
     });
 
     describe('Ranged delays', function() {

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -4,93 +4,99 @@ var assert = require('assert');
 
 var ResponseDelay = require('../../lib/services/response-delay');
 
-describe('Response delay', function() {
-    var responseDelay;
+describe('Response delay', function () {
+  var responseDelay;
 
-    beforeEach(function() {
-        responseDelay = new ResponseDelay();
+  beforeEach(function () {
+    responseDelay = new ResponseDelay();
+  });
+
+  describe('No delay', function () {
+    it('should have no delay by default', function () {
+      assert(responseDelay.delayTimeInMs() === 0);
     });
 
-    describe('No delay', function() {
-        it('should have no delay by default', function() {
-            assert(responseDelay.delayTimeInMs() === 0);
-        });
-
-        it('should have no delay when given null parameter', function() {
-            assert(responseDelay.delayTimeInMs(null) === 0);
-        });
-
-        it('should have no delay when given a parameter that coerce to false', function() {
-            assert(responseDelay.delayTimeInMs(false) === 0);
-            assert(responseDelay.delayTimeInMs(0) === 0);
-            assert(responseDelay.delayTimeInMs('') === 0);
-            assert(responseDelay.delayTimeInMs(NaN) === 0);
-        });
+    it('should have no delay when given null parameter', function () {
+      assert(responseDelay.delayTimeInMs(null) === 0);
     });
 
-    describe('Simple delays', function() {
-        it('should have a simple delay when given a number', function() {
-            assert(responseDelay.delayTimeInMs(42) === 42);
-        });
+    it('should have no delay when given a parameter that coerce to false', function () {
+      assert(responseDelay.delayTimeInMs(false) === 0);
+      assert(responseDelay.delayTimeInMs(0) === 0);
+      assert(responseDelay.delayTimeInMs('') === 0);
+      assert(responseDelay.delayTimeInMs(NaN) === 0);
+    });
+  });
 
-        it('should have a simple delay when given a string that coerce to a number', function() {
-            assert(responseDelay.delayTimeInMs('42') === 42);
-        });
+  describe('Simple delays', function () {
+    it('should have a simple delay when given a number', function () {
+      assert(responseDelay.delayTimeInMs(42) === 42);
     });
 
-    describe('Ranged delays', function() {
-        describe('Lower range', function() {
-            beforeEach(function() {
-                var fakeRandomNumberGenerator = function() {return 0;};
-                responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
-            });
-
-            it('should have minimum delay of 500ms when using auto parameter', function() {
-                assert(responseDelay.delayTimeInMs('auto') === 500);
-            });
-
-            it('should have minimum delay of 150ms when using fast parameter', function() {
-                assert(responseDelay.delayTimeInMs('fast') === 150);
-            });
-
-            it('should have minimum delay of 1500ms when using slow parameter', function() {
-                assert(responseDelay.delayTimeInMs('slow') === 1500);
-            });
-
-            it('should have minimum delay of 1ms when given an invalid parameter', function() {
-                assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
-            });
-        });
-
-        describe('Upper range', function() {
-            beforeEach(function() {
-                var fakeRandomNumberGenerator = function() {return 1;};
-                responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
-            });
-
-            it('should have maximum delay of 1750ms when using auto parameter', function() {
-                assert(responseDelay.delayTimeInMs('auto') === 1750);
-            });
-
-            it('should have maximum delay of 1000ms when using fast parameter', function() {
-                assert(responseDelay.delayTimeInMs('fast') === 1000);
-            });
-
-            it('should have maximum delay of 3000ms when using slow parameter', function() {
-                assert(responseDelay.delayTimeInMs('slow') === 3000);
-            });
-
-            it('should have maximum delay of 1ms when given an invalid parameter', function() {
-                assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
-            });
-        });
-
-        it('should round delays to the millisecond', function() {
-            var fakeRandomNumberGenerator = function() {return 0.001;};
-            responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
-
-            assert(responseDelay.delayTimeInMs('fast') === 150);
-        });
+    it('should have a simple delay when given a string that coerce to a number', function () {
+      assert(responseDelay.delayTimeInMs('42') === 42);
     });
+  });
+
+  describe('Ranged delays', function () {
+    describe('Lower range', function () {
+      beforeEach(function () {
+        var fakeRandomNumberGenerator = function () {
+          return 0;
+        };
+        responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+      });
+
+      it('should have minimum delay of 500ms when using auto parameter', function () {
+        assert(responseDelay.delayTimeInMs('auto') === 500);
+      });
+
+      it('should have minimum delay of 150ms when using fast parameter', function () {
+        assert(responseDelay.delayTimeInMs('fast') === 150);
+      });
+
+      it('should have minimum delay of 1500ms when using slow parameter', function () {
+        assert(responseDelay.delayTimeInMs('slow') === 1500);
+      });
+
+      it('should have minimum delay of 1ms when given an invalid parameter', function () {
+        assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
+      });
+    });
+
+    describe('Upper range', function () {
+      beforeEach(function () {
+        var fakeRandomNumberGenerator = function () {
+          return 1;
+        };
+        responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+      });
+
+      it('should have maximum delay of 1750ms when using auto parameter', function () {
+        assert(responseDelay.delayTimeInMs('auto') === 1750);
+      });
+
+      it('should have maximum delay of 1000ms when using fast parameter', function () {
+        assert(responseDelay.delayTimeInMs('fast') === 1000);
+      });
+
+      it('should have maximum delay of 3000ms when using slow parameter', function () {
+        assert(responseDelay.delayTimeInMs('slow') === 3000);
+      });
+
+      it('should have maximum delay of 1ms when given an invalid parameter', function () {
+        assert(responseDelay.delayTimeInMs('invalid parameter') === 1);
+      });
+    });
+
+    it('should round delays to the millisecond', function () {
+      var fakeRandomNumberGenerator = function () {
+        return 0.001;
+      };
+      responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+
+      assert(responseDelay.delayTimeInMs('fast') === 150);
+    });
+  });
 });
 

--- a/test/unit/response-delay.spec.js
+++ b/test/unit/response-delay.spec.js
@@ -89,6 +89,26 @@ describe('Response delay', function () {
       });
     });
 
+    describe('Custom ranges', function() {
+      it('should use the given upper bound to calculate the delay', function () {
+        var fakeRandomNumberGenerator = function () {
+          return 1;
+        };
+        responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+
+        assert.equal(responseDelay.delayTimeInMs({lowerBound: 50, upperBound: 100}), 100);
+      });
+
+      it('should use the given lower bound to calculate the delay', function () {
+        var fakeRandomNumberGenerator = function () {
+          return 0;
+        };
+        responseDelay = new ResponseDelay(fakeRandomNumberGenerator);
+
+        assert.equal(responseDelay.delayTimeInMs({lowerBound: 50, upperBound: 100}), 50);
+      });
+    });
+
     it('should round delays to the millisecond', function () {
       var fakeRandomNumberGenerator = function () {
         return 0.001;


### PR DESCRIPTION
Aim of the pull request : To be able to define custom ranges for delays when running connect-prism.

Scope of the pull request :
- Added unit tests on ResponseDelay function (I needed to inject Math.random to make my tests reproducibles)
- Fixed a bug when ResponseDelay was returning a value between 500 and 2250ms for auto mode (expected was between 500 and 1750ms)
- Add support for providing a custom object specifying lower and upper bounds.
- Global refactoring of ResponseDelay function
- Added .editorconfig to use auto reformating from my editor
- Watch also tests files when running `npm run test:watch`

I did all my code using node 0.10 and npm 2.15.1 (that was a time travel ^^). So I should not have broken retro-compatibility for the lib.
I have broken my pull request in a lot of commits to show you the path I have taken. Every commit is buildable and working, If you like, I can squash them together.